### PR TITLE
refactor(module): rename module to guppy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# go-w3up
+# guppy
 
 A w3up client in golang. ⚠️ Heavily WIP.
 
 ## Install
 
 ```sh
-go get github.com/storacha/go-w3up
+go get github.com/storacha/guppy
 ```
 
 ## Usage
@@ -27,8 +27,8 @@ import (
 
   "github.com/web3-storage/go-ucanto/did"
   "github.com/web3-storage/go-ucanto/principal/ed25519/signer"
-  "github.com/storacha/go-w3up/client"
-  "github.com/storacha/go-w3up/delegation"
+  "github.com/storacha/guppy/client"
+  "github.com/storacha/guppy/delegation"
 )
 
 // private key to sign invocation UCAN with
@@ -122,11 +122,11 @@ Proofs are delegations to your DID enabling it to perform tasks. Currently the b
 
 ## API
 
-[pkg.go.dev Reference](https://pkg.go.dev/github.com/storacha/go-w3up)
+[pkg.go.dev Reference](https://pkg.go.dev/github.com/storacha/guppy)
 
 ## Contributing
 
-Feel free to join in. All welcome. Please [open an issue](https://github.com/storacha/go-w3up/issues)!
+Feel free to join in. All welcome. Please [open an issue](https://github.com/storacha/guppy/issues)!
 
 ## License
 

--- a/car/sharding/sharding_test.go
+++ b/car/sharding/sharding_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/storacha/go-ucanto/core/ipld"
 	"github.com/storacha/go-ucanto/core/ipld/block"
 	"github.com/storacha/go-ucanto/core/ipld/hash/sha256"
-	"github.com/storacha/go-w3up/car/sharding"
+	"github.com/storacha/guppy/car/sharding"
 	"github.com/stretchr/testify/require"
 )
 

--- a/client/client.go
+++ b/client/client.go
@@ -33,8 +33,8 @@ import (
 	"github.com/storacha/go-ucanto/principal/ed25519/signer"
 	ucanhttp "github.com/storacha/go-ucanto/transport/http"
 	"github.com/storacha/go-ucanto/ucan"
-	"github.com/storacha/go-w3up/capability/uploadadd"
-	"github.com/storacha/go-w3up/capability/uploadlist"
+	"github.com/storacha/guppy/capability/uploadadd"
+	"github.com/storacha/guppy/capability/uploadlist"
 )
 
 // UploadAdd registers an "upload" with the service. The issuer needs proof of

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -44,7 +44,7 @@ import (
 	"github.com/storacha/go-ucanto/ucan"
 	"github.com/stretchr/testify/require"
 
-	"github.com/storacha/go-w3up/client"
+	"github.com/storacha/guppy/client"
 )
 
 func TestBlobAdd(t *testing.T) {

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -23,9 +23,9 @@ import (
 	"github.com/storacha/go-ucanto/core/result"
 	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/principal"
-	"github.com/storacha/go-w3up/car/sharding"
-	"github.com/storacha/go-w3up/client"
-	"github.com/storacha/go-w3up/cmd/util"
+	"github.com/storacha/guppy/car/sharding"
+	"github.com/storacha/guppy/client"
+	"github.com/storacha/guppy/cmd/util"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -18,7 +18,7 @@ import (
 	"github.com/storacha/go-ucanto/principal/ed25519/signer"
 	"github.com/storacha/go-ucanto/transport/car"
 	"github.com/storacha/go-ucanto/transport/http"
-	cdg "github.com/storacha/go-w3up/delegation"
+	cdg "github.com/storacha/guppy/delegation"
 )
 
 const defaultServiceName = "staging.up.storacha.network"

--- a/cmd/w3.go
+++ b/cmd/w3.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/result"
-	"github.com/storacha/go-w3up/capability/uploadlist"
-	"github.com/storacha/go-w3up/client"
-	"github.com/storacha/go-w3up/cmd/util"
+	"github.com/storacha/guppy/capability/uploadlist"
+	"github.com/storacha/guppy/client"
+	"github.com/storacha/guppy/cmd/util"
 	"github.com/urfave/cli/v2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/storacha/go-w3up
+module github.com/storacha/guppy
 
 go 1.23.3
 


### PR DESCRIPTION
# Goals

Adopt very sterile business like name for this repo. JK let's just name it after a fish

# Implementation

Replace all instances of go-w3up to guppy.