### PR TITLE
refactor: Client gets a file for each invocation

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -205,7 +205,7 @@ func uploadDirectory(ctx context.Context, paths []string, signer principal.Signe
 }
 
 func addBlob(ctx context.Context, content io.Reader, signer principal.Signer, conn uclient.Connection, space did.DID, proofs []delegation.Delegation, receiptsURL *url.URL) (multihash.Multihash, error) {
-	contentHash, _, err := client.BlobAdd(ctx, content, signer, space, receiptsURL, client.WithConnection(conn), client.WithProofs(proofs))
+	contentHash, _, err := client.SpaceBlobAdd(ctx, content, signer, space, receiptsURL, client.WithConnection(conn), client.WithProofs(proofs))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/spaceblobadd.go
+++ b/pkg/client/spaceblobadd.go
@@ -33,104 +33,9 @@ import (
 	"github.com/storacha/go-ucanto/principal/ed25519/signer"
 	ucanhttp "github.com/storacha/go-ucanto/transport/http"
 	"github.com/storacha/go-ucanto/ucan"
-	"github.com/storacha/guppy/pkg/capability/uploadadd"
-	"github.com/storacha/guppy/pkg/capability/uploadlist"
 )
 
-// UploadAdd registers an "upload" with the service. The issuer needs proof of
-// `upload/add` delegated capability.
-//
-// Required delegated capability proofs: `upload/add`
-//
-// The `issuer` is the signing authority that is issuing the UCAN invocation.
-//
-// The `space` is the resource the invocation applies to. It is typically the
-// DID of a space.
-//
-// The `params` are caveats required to perform an `upload/add` invocation.
-func UploadAdd(issuer principal.Signer, space did.DID, params uploadadd.Caveat, options ...Option) (receipt.Receipt[*uploadadd.Success, *uploadadd.Failure], error) {
-	cfg := ClientConfig{conn: DefaultConnection}
-	for _, opt := range options {
-		if err := opt(&cfg); err != nil {
-			return nil, err
-		}
-	}
-
-	inv, err := invocation.Invoke(
-		issuer,
-		cfg.conn.ID(),
-		uploadadd.NewCapability(space, params),
-		convertToInvocationOptions(cfg)...,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := uclient.Execute([]invocation.Invocation{inv}, cfg.conn)
-	if err != nil {
-		return nil, err
-	}
-
-	rcptlnk, ok := resp.Get(inv.Link())
-	if !ok {
-		return nil, fmt.Errorf("receipt not found: %s", inv.Link())
-	}
-
-	reader, err := uploadadd.NewReceiptReader()
-	if err != nil {
-		return nil, err
-	}
-
-	return reader.Read(rcptlnk, resp.Blocks())
-}
-
-// UploadList returns a paginated list of uploads in a space.
-//
-// Required delegated capability proofs: `upload/list`
-//
-// The `issuer` is the signing authority that is issuing the UCAN invocation.
-//
-// The `space` is the resource the invocation applies to. It is typically the
-// DID of a space.
-//
-// The `params` are caveats required to perform an `upload/list` invocation.
-func UploadList(issuer principal.Signer, space did.DID, params uploadlist.Caveat, options ...Option) (receipt.Receipt[*uploadlist.Success, *uploadlist.Failure], error) {
-	cfg := ClientConfig{conn: DefaultConnection}
-	for _, opt := range options {
-		if err := opt(&cfg); err != nil {
-			return nil, err
-		}
-	}
-
-	inv, err := invocation.Invoke(
-		issuer,
-		cfg.conn.ID(),
-		uploadlist.NewCapability(space, params),
-		convertToInvocationOptions(cfg)...,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := uclient.Execute([]invocation.Invocation{inv}, cfg.conn)
-	if err != nil {
-		return nil, err
-	}
-
-	rcptlnk, ok := resp.Get(inv.Link())
-	if !ok {
-		return nil, fmt.Errorf("receipt not found: %s", inv.Link())
-	}
-
-	reader, err := uploadlist.NewReceiptReader()
-	if err != nil {
-		return nil, err
-	}
-
-	return reader.Read(rcptlnk, resp.Blocks())
-}
-
-// BlobAdd adds a blob to the service. The issuer needs proof of
+// SpaceBlobAdd adds a blob to the service. The issuer needs proof of
 // `space/blob/add` delegated capability.
 //
 // Required delegated capability proofs: `space/blob/add`
@@ -142,7 +47,7 @@ func UploadList(issuer principal.Signer, space did.DID, params uploadlist.Caveat
 //
 // Returns the multihash of the added blob and the location commitment that contains details about where the
 // blob can be located, or an error if something went wrong.
-func BlobAdd(ctx context.Context, content io.Reader, issuer principal.Signer, space did.DID, receiptsURL *url.URL, options ...Option) (multihash.Multihash, delegation.Delegation, error) {
+func SpaceBlobAdd(ctx context.Context, content io.Reader, issuer principal.Signer, space did.DID, receiptsURL *url.URL, options ...Option) (multihash.Multihash, delegation.Delegation, error) {
 	cfg := ClientConfig{conn: DefaultConnection}
 	for _, opt := range options {
 		if err := opt(&cfg); err != nil {

--- a/pkg/client/spaceblobadd_test.go
+++ b/pkg/client/spaceblobadd_test.go
@@ -93,7 +93,7 @@ func TestBlobAdd(t *testing.T) {
 
 	testBlob := bytes.NewReader([]byte("test"))
 
-	_, _, err = client.BlobAdd(context.Background(), testBlob, issuer, space.DID(), receiptsURL, client.WithConnection(conn), client.WithProof(proof))
+	_, _, err = client.SpaceBlobAdd(context.Background(), testBlob, issuer, space.DID(), receiptsURL, client.WithConnection(conn), client.WithProof(proof))
 	require.NoError(t, err)
 }
 

--- a/pkg/client/uploadadd.go
+++ b/pkg/client/uploadadd.go
@@ -1,0 +1,59 @@
+package client
+
+import (
+	"fmt"
+
+	uclient "github.com/storacha/go-ucanto/client"
+	"github.com/storacha/go-ucanto/core/invocation"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/go-ucanto/principal"
+	"github.com/storacha/guppy/pkg/capability/uploadadd"
+)
+
+// UploadAdd registers an "upload" with the service. The issuer needs proof of
+// `upload/add` delegated capability.
+//
+// Required delegated capability proofs: `upload/add`
+//
+// The `issuer` is the signing authority that is issuing the UCAN invocation.
+//
+// The `space` is the resource the invocation applies to. It is typically the
+// DID of a space.
+//
+// The `params` are caveats required to perform an `upload/add` invocation.
+func UploadAdd(issuer principal.Signer, space did.DID, params uploadadd.Caveat, options ...Option) (receipt.Receipt[*uploadadd.Success, *uploadadd.Failure], error) {
+	cfg := ClientConfig{conn: DefaultConnection}
+	for _, opt := range options {
+		if err := opt(&cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	inv, err := invocation.Invoke(
+		issuer,
+		cfg.conn.ID(),
+		uploadadd.NewCapability(space, params),
+		convertToInvocationOptions(cfg)...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := uclient.Execute([]invocation.Invocation{inv}, cfg.conn)
+	if err != nil {
+		return nil, err
+	}
+
+	rcptlnk, ok := resp.Get(inv.Link())
+	if !ok {
+		return nil, fmt.Errorf("receipt not found: %s", inv.Link())
+	}
+
+	reader, err := uploadadd.NewReceiptReader()
+	if err != nil {
+		return nil, err
+	}
+
+	return reader.Read(rcptlnk, resp.Blocks())
+}

--- a/pkg/client/uploadlist.go
+++ b/pkg/client/uploadlist.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"fmt"
+
+	uclient "github.com/storacha/go-ucanto/client"
+	"github.com/storacha/go-ucanto/core/invocation"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/go-ucanto/principal"
+	"github.com/storacha/guppy/pkg/capability/uploadlist"
+)
+
+// UploadList returns a paginated list of uploads in a space.
+//
+// Required delegated capability proofs: `upload/list`
+//
+// The `issuer` is the signing authority that is issuing the UCAN invocation.
+//
+// The `space` is the resource the invocation applies to. It is typically the
+// DID of a space.
+//
+// The `params` are caveats required to perform an `upload/list` invocation.
+func UploadList(issuer principal.Signer, space did.DID, params uploadlist.Caveat, options ...Option) (receipt.Receipt[*uploadlist.Success, *uploadlist.Failure], error) {
+	cfg := ClientConfig{conn: DefaultConnection}
+	for _, opt := range options {
+		if err := opt(&cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	inv, err := invocation.Invoke(
+		issuer,
+		cfg.conn.ID(),
+		uploadlist.NewCapability(space, params),
+		convertToInvocationOptions(cfg)...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := uclient.Execute([]invocation.Invocation{inv}, cfg.conn)
+	if err != nil {
+		return nil, err
+	}
+
+	rcptlnk, ok := resp.Get(inv.Link())
+	if !ok {
+		return nil, fmt.Errorf("receipt not found: %s", inv.Link())
+	}
+
+	reader, err := uploadlist.NewReceiptReader()
+	if err != nil {
+		return nil, err
+	}
+
+	return reader.Read(rcptlnk, resp.Blocks())
+}


### PR DESCRIPTION
* Place each invocation's implementation in its own file
* Divide tests similarly (but only one invocation currently has tests)
* Use full name of ability in invocation function name (specifically, `BlobAdd` -> `SpaceBlobAdd`)

Part of #17


#### PR Dependency Tree


* **PR #22** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)