### PR TITLE
fix: Use correct `Promise` and `Await` types

### DIFF
--- a/pkg/client/spaceblobadd_test.go
+++ b/pkg/client/spaceblobadd_test.go
@@ -21,6 +21,7 @@ import (
 	blobcap "github.com/storacha/go-libstoracha/capabilities/blob"
 	httpcap "github.com/storacha/go-libstoracha/capabilities/http"
 	spaceblobcap "github.com/storacha/go-libstoracha/capabilities/space/blob"
+	"github.com/storacha/go-libstoracha/capabilities/types"
 	captypes "github.com/storacha/go-libstoracha/capabilities/types"
 	ucancap "github.com/storacha/go-libstoracha/capabilities/ucan"
 	uploadcap "github.com/storacha/go-libstoracha/capabilities/upload"
@@ -303,8 +304,8 @@ func setupTestUCANServer(t *testing.T, serverPrincipal principal.Signer, putBlob
 			fxs := fx.NewEffects(fx.WithFork(forks...))
 
 			ok := spaceblobcap.AddOk{
-				Site: spaceblobcap.Promise{
-					UcanAwait: spaceblobcap.Await{
+				Site: types.Promise{
+					UcanAwait: types.Await{
 						Selector: ".out.ok.site",
 						Link:     acceptInv.Root().Link(),
 					},


### PR DESCRIPTION
I'm not sure why this hasn't been failing the build. It fails when I run tests locally without this change.





#### PR Dependency Tree


* **PR #24**
  * **PR #26** 👈
    * **PR #25**
      * **PR #27**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)