### PR TITLE
fix: Connect error to cause with `%w`

### DIFF
--- a/pkg/client/spaceblobadd.go
+++ b/pkg/client/spaceblobadd.go
@@ -97,7 +97,7 @@ func SpaceBlobAdd(ctx context.Context, content io.Reader, issuer principal.Signe
 
 	_, failErr := result.Unwrap(result.MapError(rcpt.Out(), failure.FromFailureModel))
 	if failErr != nil {
-		return nil, nil, fmt.Errorf("blob add failed: %+v", failErr)
+		return nil, nil, fmt.Errorf("blob add failed: %w", failErr)
 	}
 
 	var allocateTask, putTask, acceptTask invocation.Invocation


### PR DESCRIPTION
`fmt.Errorf()` treats `%w` specially, by making the orignal interpolated error available on the wrapped error as `Unwrap()`. Otherwise, it's identical to `%v`.










#### PR Dependency Tree


* **PR #27** 👈
  * **PR #28**
    * **PR #29**
      * **PR #30**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)