### PR TITLE
feat: RequestAccess returns the AuthorizeOk

### DIFF
--- a/pkg/client/requestaccess.go
+++ b/pkg/client/requestaccess.go
@@ -100,7 +100,5 @@ func (c *Client) RequestAccess(account string) (access.AuthorizeOk, error) {
 		return access.AuthorizeOk{}, fmt.Errorf("`access/authorize` failed: %w", failErr)
 	}
 
-	fmt.Printf("Access granted: %+v\n", authorizeOk)
-
 	return authorizeOk, nil
 }

--- a/pkg/client/requestaccess.go
+++ b/pkg/client/requestaccess.go
@@ -1,12 +1,20 @@
 package client
 
 import (
+	_ "embed"
 	"fmt"
 
+	"github.com/storacha/guppy/pkg/client/nodevalue"
+
 	"github.com/storacha/go-libstoracha/capabilities/access"
+	captypes "github.com/storacha/go-libstoracha/capabilities/types"
 	uclient "github.com/storacha/go-ucanto/client"
 	"github.com/storacha/go-ucanto/core/invocation"
-	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/go-ucanto/core/receipt"
+	"github.com/storacha/go-ucanto/core/result"
+	"github.com/storacha/go-ucanto/core/result/failure"
+	"github.com/storacha/go-ucanto/core/result/failure/datamodel"
+	serverdatamodel "github.com/storacha/go-ucanto/server/datamodel"
 )
 
 // spaceAccess is the set of capabilities required by the agent to manage a
@@ -28,22 +36,71 @@ var spaceAccess = []access.CapabilityRequest{
 // The [issuer] is the Agent which would like to act as the Account.
 //
 // The [account] is the Account the Agent would like to act as.
-func (c *Client) RequestAccess(account did.DID) error {
-	accountStr := account.String()
+func (c *Client) RequestAccess(account string) (access.AuthorizeOk, error) {
 	caveats := access.AuthorizeCaveats{
-		Iss: &accountStr,
+		Iss: &account,
 		Att: spaceAccess,
 	}
 
 	inv, err := access.Authorize.Invoke(c.issuer, c.connection.ID(), c.issuer.DID().String(), caveats)
 	if err != nil {
-		return fmt.Errorf("generating invocation: %w", err)
+		return access.AuthorizeOk{}, fmt.Errorf("generating invocation: %w", err)
 	}
 
-	_, err = uclient.Execute([]invocation.Invocation{inv}, c.connection)
+	resp, err := uclient.Execute([]invocation.Invocation{inv}, c.connection)
 	if err != nil {
-		return fmt.Errorf("sending invocation: %w", err)
+		return access.AuthorizeOk{}, fmt.Errorf("sending invocation: %w", err)
 	}
 
-	return nil
+	rcptlnk, ok := resp.Get(inv.Link())
+	if !ok {
+		return access.AuthorizeOk{}, fmt.Errorf("receipt not found: %s", inv.Link())
+	}
+
+	reader, err := receipt.NewReceiptReaderFromTypes[access.AuthorizeOk, serverdatamodel.HandlerExecutionErrorModel](access.AuthorizeOkType(), serverdatamodel.HandlerExecutionErrorType(), captypes.Converters...)
+	if err != nil {
+		return access.AuthorizeOk{}, fmt.Errorf("generating receipt reader: %w", err)
+	}
+
+	rcpt, err := reader.Read(rcptlnk, resp.Blocks())
+	if err != nil {
+		anyRcpt, err := receipt.NewAnyReceiptReader().Read(rcptlnk, resp.Blocks())
+		if err != nil {
+			return access.AuthorizeOk{}, fmt.Errorf("reading receipt as any: %w", err)
+		}
+		okNode, errorNode := result.Unwrap(anyRcpt.Out())
+
+		if okNode != nil {
+			okValue, err := nodevalue.NodeValue(okNode)
+			if err != nil {
+				return access.AuthorizeOk{}, fmt.Errorf("reading `access/authorize` ok output: %w", err)
+			}
+			return access.AuthorizeOk{}, fmt.Errorf("`access/authorize` succeeded with unexpected output: %#v", okValue)
+		}
+
+		errorValue, err := nodevalue.NodeValue(errorNode)
+		if err != nil {
+			return access.AuthorizeOk{}, fmt.Errorf("reading `access/authorize` error output: %w", err)
+		}
+		return access.AuthorizeOk{}, fmt.Errorf("`access/authorize` failed with unexpected error: %#v", errorValue)
+	}
+
+	authorizeOk, failErr := result.Unwrap(
+		result.MapError(
+			result.MapError(
+				rcpt.Out(),
+				func(errorModel serverdatamodel.HandlerExecutionErrorModel) datamodel.FailureModel {
+					return datamodel.FailureModel(errorModel.Cause)
+				},
+			),
+			failure.FromFailureModel,
+		),
+	)
+	if failErr != nil {
+		return access.AuthorizeOk{}, fmt.Errorf("`access/authorize` failed: %w", failErr)
+	}
+
+	fmt.Printf("Access granted: %+v\n", authorizeOk)
+
+	return authorizeOk, nil
 }


### PR DESCRIPTION
~Waiting on https://github.com/storacha/go-libstoracha/pull/35; temporary copy of relevant code is in this PR for now.~

Notably, there's a ton of boilerplate code in this and the other invoking functions/methods. We'll need to abstract some of that stuff soon probably to a `client.invokeAndExecute()` like in JS.

















#### PR Dependency Tree


* **PR #34** 👈
  * **PR #32**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)