### PR TITLE
refactor: Migrate `urfave/cli` from v2 to v3

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -26,49 +26,49 @@ import (
 	"github.com/storacha/guppy/cmd/util"
 	"github.com/storacha/guppy/pkg/car/sharding"
 	"github.com/storacha/guppy/pkg/client"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 // upload handles file and directory uploads to Storacha
-func upload(cCtx *cli.Context) error {
+func upload(ctx context.Context, cmd *cli.Command) error {
 	signer := util.MustGetSigner()
 	conn := util.MustGetConnection()
-	space := util.MustParseDID(cCtx.String("space"))
-	proofs := []delegation.Delegation{util.MustGetProof(cCtx.String("proof"))}
+	space := util.MustParseDID(cmd.String("space"))
+	proofs := []delegation.Delegation{util.MustGetProof(cmd.String("proof"))}
 	receiptsURL := util.MustGetReceiptsURL()
 
 	// Handle options
-	isCAR := cCtx.String("car") != ""
-	isJSON := cCtx.Bool("json")
-	// isVerbose := cCtx.Bool("verbose")
-	isWrap := cCtx.Bool("wrap")
-	// shardSize := cCtx.Int("shard-size")
+	isCAR := cmd.String("car") != ""
+	isJSON := cmd.Bool("json")
+	// isVerbose := cmd.Bool("verbose")
+	isWrap := cmd.Bool("wrap")
+	// shardSize := cmd.Int("shard-size")
 
 	var paths []string
 	if isCAR {
-		paths = []string{cCtx.String("car")}
+		paths = []string{cmd.String("car")}
 	} else {
-		paths = cCtx.Args().Slice()
+		paths = cmd.Args().Slice()
 	}
 
 	var root ipld.Link
 	if isCAR {
 		fmt.Printf("Uploading %s...\n", paths[0])
 		var err error
-		root, err = uploadCAR(cCtx.Context, paths[0], signer, conn, space, proofs, receiptsURL)
+		root, err = uploadCAR(ctx, paths[0], signer, conn, space, proofs, receiptsURL)
 		if err != nil {
 			return err
 		}
 	} else {
 		if len(paths) == 1 && !isWrap {
 			var err error
-			root, err = uploadFile(cCtx.Context, paths[0], signer, conn, space, proofs, receiptsURL)
+			root, err = uploadFile(ctx, paths[0], signer, conn, space, proofs, receiptsURL)
 			if err != nil {
 				return err
 			}
 		} else {
 			var err error
-			root, err = uploadDirectory(cCtx.Context, paths, signer, conn, space, proofs, receiptsURL)
+			root, err = uploadDirectory(ctx, paths, signer, conn, space, proofs, receiptsURL)
 			if err != nil {
 				return err
 			}

--- a/cmd/w3.go
+++ b/cmd/w3.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -10,11 +11,11 @@ import (
 	"github.com/storacha/guppy/cmd/util"
 	"github.com/storacha/guppy/pkg/capability/uploadlist"
 	"github.com/storacha/guppy/pkg/client"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v3"
 )
 
 func main() {
-	app := &cli.App{
+	app := &cli.Command{
 		Name:  "w3",
 		Usage: "interact with the web3.storage API",
 		Commands: []*cli.Command{
@@ -101,22 +102,22 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	if err := app.Run(context.Background(), os.Args); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func whoami(cCtx *cli.Context) error {
+func whoami(ctx context.Context, cmd *cli.Command) error {
 	s := util.MustGetSigner()
 	fmt.Println(s.DID())
 	return nil
 }
 
-func ls(cCtx *cli.Context) error {
+func ls(ctx context.Context, cmd *cli.Command) error {
 	signer := util.MustGetSigner()
 	conn := util.MustGetConnection()
-	space := util.MustParseDID(cCtx.String("space"))
-	proof := util.MustGetProof(cCtx.String("proof"))
+	space := util.MustParseDID(cmd.String("space"))
+	proof := util.MustGetProof(cmd.String("proof"))
 
 	rcpt, err := client.UploadList(
 		signer,
@@ -136,7 +137,7 @@ func ls(cCtx *cli.Context) error {
 
 	for _, r := range lsSuccess.Results {
 		fmt.Printf("%s\n", r.Root)
-		if cCtx.Bool("shards") {
+		if cmd.Bool("shards") {
 			for _, s := range r.Shards {
 				fmt.Printf("\t%s\n", s)
 			}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/storacha/go-libstoracha v0.0.7
 	github.com/storacha/go-ucanto v0.3.2
 	github.com/stretchr/testify v1.10.0
-	github.com/urfave/cli/v2 v2.25.7
+	github.com/urfave/cli/v3 v3.3.8
 )
 
 require (
@@ -68,8 +68,8 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/ucan-wg/go-ucan v0.0.0-20240916120445-37f52863156c // indirect
+	github.com/urfave/cli/v2 v2.0.0 // indirect
 	github.com/whyrusleeping/cbor-gen v0.3.1 // indirect
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.opentelemetry.io/otel v1.35.0 // indirect
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -487,9 +487,10 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/ucan-wg/go-ucan v0.0.0-20240916120445-37f52863156c h1:A1pMNIlHPnJ6KROqNc6SKg7QlSiQA6umiEoy89Os4cM=
 github.com/ucan-wg/go-ucan v0.0.0-20240916120445-37f52863156c/go.mod h1:IiRc1OKWUk7FziOTWmOo7iwbcEMr7ch0lgs3UrF13pU=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.0.0 h1:+HU9SCbu8GnEUFtIBfuUNXN39ofWViIEJIp6SURMpCg=
 github.com/urfave/cli/v2 v2.0.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
-github.com/urfave/cli/v2 v2.25.7 h1:VAzn5oq403l5pHjc4OhD54+XGO9cdKVL/7lDjF+iKUs=
-github.com/urfave/cli/v2 v2.25.7/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
+github.com/urfave/cli/v3 v3.3.8 h1:BzolUExliMdet9NlJ/u4m5vHSotJ3PzEqSAZ1oPMa/E=
+github.com/urfave/cli/v3 v3.3.8/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
 github.com/warpfork/go-testmark v0.12.1 h1:rMgCpJfwy1sJ50x0M0NgyphxYYPMOODIJHhsXyEHU0s=
 github.com/warpfork/go-testmark v0.12.1/go.mod h1:kHwy7wfvGSPh1rQJYKayD4AbtNaeyZdcGi9tNJTaa5Y=
 github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0 h1:GDDkbFiaK8jsSDJfjId/PEGEShv6ugrt4kYsC5UIDaQ=
@@ -499,8 +500,6 @@ github.com/whyrusleeping/cbor-gen v0.3.1 h1:82ioxmhEYut7LBVGhGq8xoRkXPLElVuh5mV6
 github.com/whyrusleeping/cbor-gen v0.3.1/go.mod h1:pM99HXyEbSQHcosHc0iW7YFmwnscr+t9Te4ibko05so=
 github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=
 github.com/wlynxg/anet v0.0.5/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
-github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This makes using the context work better. It looks like `cCtx.Context` did work before, but the docs say this ["This allows handler functions to utilize context.Context for blocking/time-specific operations"](https://cli.urfave.org/migrate-v2-to-v3/#handler-function-signatures-changes), so I think there are probably some hitches.

I didn't actually notice we were using (or could even get away with using) `cCtx.Context` until I was going through the migration, but it was so straightforward I was already pretty much done, so it seems like we may as well.


#### PR Dependency Tree


* **PR #33**
  * **PR #34**
    * **PR #35** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)