### PR TITLE
chore: Update README for `login` command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,8 +22,8 @@ builds:
       - linux
       - windows
       - darwin
-    main: ./cmd/w3.go
-    binary: w3
+    main: ./cmd/main.go
+    binary: guppy
 
 archives:
   - format: tar.gz

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To bring your own pre-authorized identity, instantiate the client with the optio
 
 ### CLI
 
-The CLI will automatically generate an identity for you and store it in `~/.w3up/config`. Like the library, there are two ways to authenticate the CLI client: interactively, or by authorizing in advance.
+The CLI will automatically generate an identity for you and store it in `~/.guppy/config`. Like the library, there are two ways to authenticate the CLI client: interactively, or by authorizing in advance.
 
 To authorize interactively, use `go run ./cmd login` and follow the prompts.
 
@@ -56,20 +56,20 @@ signer, _ := signer.Parse("MgCb+bRGl02JqlWMPUxCyntxlYj0T/zLtR2tn8LFvw6+Yke0BKAP/
 
 ### Obtain proofs
 
-Proofs are delegations to your DID enabling it to perform tasks. Currently the best way to obtain proofs that will allow you to interact with the web3.storage API is to use the w3up JS CLI:
+Proofs are delegations to your DID enabling it to perform tasks. Currently the best way to obtain proofs that will allow you to interact with the Storacha Network is to use the Storacha JS CLI:
 
 1. [Generate a DID](#generate-a-did) and make a note of it (the string starting with `did:key:...`)
-1. Install w3 CLI:
+2. Install w3 CLI:
     ```sh
-    npm install -g @web3-storage/w3cli
+    npm install -g @storacha/cli
     ```
-1. Create a space:
+3. Create a space:
     ```sh
-    w3 space create <NAME>
+    storacha space create <NAME>
     ```
-1. Delegate capabilities to your DID:
+4. Delegate capabilities to your DID:
     ```sh
-    w3 delegation create -c 'store/*' -c 'upload/*' <DID>`
+    storacha delegation create -c 'store/*' -c 'upload/*' <DID>`
     ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Output should look something like:
 # did:key:z6Mkh9TtUbFJcUHhMmS9dEbqpBbHPbL9oxg1zziWn1CYCNZ2
 MgCb+bRGl02JqlWMPUxCyntxlYj0T/zLtR2tn8LFvw6+Yke0BKAP/OUu2tXpd+tniEoOzB3pxqxHZpRhrZl1UYUeraT0=
 ```
-You can use the private key (the line starting `Mg...`) in the CLI by setting the environment variable `W3UP_PRIVATE_KEY`. Alternatively you can use it programmatically after parsing it:
+
+You can use the private key (the line starting `Mg...`) in the CLI by setting the environment variable `GUPPY_PRIVATE_KEY`. Alternatively you can use it programmatically after parsing it:
 
 ```go
 package main

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ To authorize interactively, use `go run ./cmd login` and follow the prompts.
 
 To authorize in advance, use `go run ./cmd whoami` to see the client's DID and then [delegate capabilities](#obtain-proofs) to that identity. Then, pass the proofs you create on the command line whenever you use the CLI.
 
+```
+NAME:
+   guppy - interact with the Storacha Network
+
+USAGE:
+   guppy [global options] command [command options] [arguments...]
+
+COMMANDS:
+   whoami      Print information about the current agent.
+   login       Authenticate this agent with your email address to gain access to all capabilities that have been delegated to it.
+   up, upload  Store a file(s) to the service and register an upload.
+   ls, list    List uploads in the current space.
+   help, h     Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --help, -h  show help
+```
+
 ## How to
 
 ### Generate a DID

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,8 +17,8 @@ import (
 
 func main() {
 	app := &cli.App{
-		Name:  "w3",
-		Usage: "interact with the web3.storage API",
+		Name:  "guppy",
+		Usage: "interact with the Storacha Network",
 		Commands: []*cli.Command{
 			{
 				Name:   "whoami",

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -27,7 +27,7 @@ func MustGetClient() *client.Client {
 		log.Fatalf("obtaining user home directory: %s", err)
 	}
 
-	datadir := path.Join(homedir, ".w3up")
+	datadir := path.Join(homedir, ".guppy")
 	datapath := path.Join(datadir, "config.json")
 
 	data, err := agentdata.ReadFromFile(datapath)

--- a/examples/byoidentity/byoidentity.go
+++ b/examples/byoidentity/byoidentity.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/storacha/go-ucanto/core/result"
+	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/go-ucanto/principal/ed25519/signer"
+	"github.com/storacha/guppy/pkg/capability/uploadlist"
+	"github.com/storacha/guppy/pkg/client"
+	"github.com/storacha/guppy/pkg/delegation"
+)
+
+func main() {
+	// private key to sign invocation UCAN with
+	keybytes, _ := os.ReadFile("path/to/private.key")
+	signer, _ := signer.FromRaw(keybytes)
+
+	// UCAN proof that signer can list uploads in this space (a delegation chain)
+	prfbytes, _ := os.ReadFile("path/to/proof.ucan")
+	proof, _ := delegation.ExtractProof(prfbytes)
+
+	// space to list uploads from
+	space, _ := did.Parse("did:key:z6MkwDuRThQcyWjqNsK54yKAmzfsiH6BTkASyiucThMtHt1y")
+
+	// nil uses the default connection to the Storacha network
+	c, _ := client.NewClient(nil, client.WithPrincipal(signer))
+
+	rcpt, _ := c.UploadList(
+		context.Background(),
+		space,
+		uploadlist.Caveat{},
+		proof,
+	)
+
+	ok, _ := result.Unwrap(rcpt.Out())
+
+	for _, r := range ok.Results {
+		fmt.Printf("%s\n", r.Root)
+	}
+}

--- a/examples/loginflow/loginflow.go
+++ b/examples/loginflow/loginflow.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/storacha/go-ucanto/core/result"
+	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/guppy/pkg/capability/uploadlist"
+	"github.com/storacha/guppy/pkg/client"
+)
+
+// Error handling omitted for brevity.
+
+func main() {
+	ctx := context.Background()
+
+	// space to list uploads from
+	space, _ := did.Parse("did:key:z6MkwDuRThQcyWjqNsK54yKAmzfsiH6BTkASyiucThMtHt1y")
+
+	// the account to log in as, which has access to the space
+	account, _ := did.Parse("mailto:example.com:ucansam")
+
+	// nil uses the default connection to the Storacha network
+	// Without `client.WithPrincipal`, the client will generate a new signer.
+	c, _ := client.NewClient(nil)
+
+	// Kick off the login flow
+	authOk, _ := c.RequestAccess(ctx, account.String())
+
+	// Start polling to see if the user has authenticated yet
+	resultChan := c.PollClaim(ctx, authOk)
+	fmt.Println("Please click the link in your email to authenticate...")
+	// Wait for the user to authenticate
+	proofs, _ := result.Unwrap(<-resultChan)
+
+	// Either add the proofs to the client to use them on any invocation...
+	c.AddProofs(proofs...)
+
+	rcpt, _ := c.UploadList(
+		context.Background(),
+		space,
+		uploadlist.Caveat{},
+		// ...Or use them for a single invocation
+		proofs...,
+	)
+
+	ok, _ := result.Unwrap(rcpt.Out())
+
+	for _, r := range ok.Results {
+		fmt.Printf("%s\n", r.Root)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"fmt"
+
 	uclient "github.com/storacha/go-ucanto/client"
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/did"
@@ -40,6 +42,11 @@ func NewClient(connection uclient.Connection, options ...Option) (*Client, error
 		c.data.Principal = newPrincipal
 	}
 
+	err := c.save()
+	if err != nil {
+		return nil, err
+	}
+
 	return &c, nil
 }
 
@@ -69,8 +76,17 @@ func (c *Client) Proofs() []delegation.Delegation {
 // AddProofs adds the given delegations to the client's data and saves it.
 func (c *Client) AddProofs(delegations ...delegation.Delegation) error {
 	c.data.Delegations = append(c.data.Delegations, delegations...)
-	if c.saveFn != nil {
-		return c.saveFn(c.data)
+	return c.save()
+}
+
+func (c *Client) save() error {
+	if c.saveFn == nil {
+		return nil
+	}
+
+	err := c.saveFn(c.data)
+	if err != nil {
+		return fmt.Errorf("saving client data: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
I've moved the code examples out to actual Go files. It's slightly less discoverable, but it means that they get checked by Go, at least through your editor. The existing example code embedded in the README had several broken things and would have been pretty frustrating to try to work from.

In doing all this, I also noticed that the environment variable for setting the key had gotten dropped, so fixing that is mixed in here too—apologies for a slightly muddled PR.







#### PR Dependency Tree


* **PR #36** 👈
  * **PR #37**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)