### PR TITLE
fix: Clean up terminal on `SIGTERM`/`SIGINT`

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"log"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/briandowns/spinner"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/result"
 	"github.com/storacha/guppy/cmd/util"
@@ -14,6 +17,8 @@ import (
 	"github.com/storacha/guppy/pkg/didmailto"
 	"github.com/urfave/cli/v2"
 )
+
+var log = logging.Logger("storoku/main")
 
 func main() {
 	app := &cli.App{
@@ -109,7 +114,28 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	// set up a context that is canceled when a command is interrupted
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// set up a signal handler to cancel the context
+	go func() {
+		interrupt := make(chan os.Signal, 1)
+		signal.Notify(interrupt, syscall.SIGTERM, syscall.SIGINT)
+
+		select {
+		case <-interrupt:
+			fmt.Println()
+			log.Info("received interrupt signal")
+			cancel()
+		case <-ctx.Done():
+		}
+
+		// Allow any further SIGTERM or SIGINT to kill process
+		signal.Stop(interrupt)
+	}()
+
+	if err := app.RunContext(ctx, os.Args); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -143,10 +169,12 @@ func login(cCtx *cli.Context) error {
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond) // Spinner: ⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏
 	s.Suffix = fmt.Sprintf(" 🔗 please click the link sent to %s to authorize this agent", email)
 	s.Start()
-	// FIXME: This is meant to clean up if we SIGINT (Ctrl+C) the process, but doesn't.
-	defer s.Stop()
 	claimedDels, err := result.Unwrap(<-resultChan)
 	s.Stop()
+
+	if cCtx.Context.Err() != nil {
+		return fmt.Errorf("login canceled: %w", cCtx.Context.Err())
+	}
 
 	if err != nil {
 		return fmt.Errorf("claiming access: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.4
 require (
 	github.com/briandowns/spinner v1.23.2
 	github.com/ipfs/go-cid v0.5.0
+	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipld/go-ipld-prime v0.21.1-0.20240917223228-6148356a4c2e
 	github.com/multiformats/go-multicodec v0.9.0
 	github.com/multiformats/go-multihash v0.2.3
@@ -45,7 +46,6 @@ require (
 	github.com/ipfs/go-ipld-format v0.6.1 // indirect
 	github.com/ipfs/go-ipld-legacy v0.2.1 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
-	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/ipfs/go-merkledag v0.11.0 // indirect
 	github.com/ipfs/go-metrics-interface v0.3.0 // indirect
 	github.com/ipfs/go-verifcid v0.0.3 // indirect


### PR DESCRIPTION
Output:

```
❯ go run ./cmd login petra@storacha.network
⠧ 🔗 please click the link sent to petra@storacha.network to authorize this agent^C
2025-06-20T12:00:30.221-0400    FATAL   storoku/main    cmd/main.go:139 login canceled: context canceled
exit status 1
```

and the cursor becomes visible again, rather than remaining hidden.


#### PR Dependency Tree


* **PR #36**
  * **PR #37** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)