### PR TITLE
refactor: Stop passing proofs through lots of calls

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -170,7 +170,6 @@ func reset(cCtx *cli.Context) error {
 }
 
 func ls(cCtx *cli.Context) error {
-	c := util.MustGetClient()
 	space := util.MustParseDID(cCtx.String("space"))
 
 	proofs := []delegation.Delegation{}
@@ -179,12 +178,12 @@ func ls(cCtx *cli.Context) error {
 		proofs = append(proofs, proof)
 	}
 
+	c := util.MustGetClient(proofs...)
+
 	listOk, err := c.UploadList(
 		cCtx.Context,
 		space,
-		uploadcap.ListCaveats{},
-		proofs...,
-	)
+		uploadcap.ListCaveats{})
 	if err != nil {
 		return err
 	}

--- a/examples/byoidentity/byoidentity.go
+++ b/examples/byoidentity/byoidentity.go
@@ -27,11 +27,12 @@ func main() {
 	// nil uses the default connection to the Storacha network
 	c, _ := client.NewClient(nil, client.WithPrincipal(signer))
 
+	c.AddProofs(proof)
+
 	listOk, _ := c.UploadList(
 		context.Background(),
 		space,
 		uploadcap.ListCaveats{},
-		proof,
 	)
 
 	for _, r := range listOk.Results {

--- a/examples/loginflow/loginflow.go
+++ b/examples/loginflow/loginflow.go
@@ -34,15 +34,13 @@ func main() {
 	// Wait for the user to authenticate
 	proofs, _ := result.Unwrap(<-resultChan)
 
-	// Either add the proofs to the client to use them on any invocation...
+	// Add the proofs to the client
 	c.AddProofs(proofs...)
 
 	listOk, _ := c.UploadList(
 		context.Background(),
 		space,
 		uploadcap.ListCaveats{},
-		// ...Or use them for a single invocation
-		proofs...,
 	)
 
 	for _, r := range listOk.Results {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -118,13 +118,14 @@ func invokeAndExecute[Caveats, Out any](
 	with ucan.Resource,
 	caveats Caveats,
 	successType schema.Type,
+	options ...delegation.Option,
 ) (result.Result[Out, failure.IPLDBuilderFailure], fx.Effects, error) {
 	pfs := make([]delegation.Proof, 0, len(c.Proofs()))
 	for _, del := range c.Proofs() {
 		pfs = append(pfs, delegation.FromDelegation(del))
 	}
 
-	inv, err := capParser.Invoke(c.Issuer(), c.Connection().ID(), with, caveats, delegation.WithProof(pfs...))
+	inv, err := capParser.Invoke(c.Issuer(), c.Connection().ID(), with, caveats, append(options, delegation.WithProof(pfs...))...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generating invocation: %w", err)
 	}

--- a/pkg/client/spaceblobadd.go
+++ b/pkg/client/spaceblobadd.go
@@ -51,7 +51,7 @@ import (
 //
 // Returns the multihash of the added blob and the location commitment that contains details about where the
 // blob can be located, or an error if something went wrong.
-func (c *Client) SpaceBlobAdd(ctx context.Context, content io.Reader, space did.DID, receiptsURL *url.URL, proofs ...delegation.Delegation) (multihash.Multihash, delegation.Delegation, error) {
+func (c *Client) SpaceBlobAdd(ctx context.Context, content io.Reader, space did.DID, receiptsURL *url.URL) (multihash.Multihash, delegation.Delegation, error) {
 	contentBytes, err := io.ReadAll(content)
 	if err != nil {
 		return nil, nil, fmt.Errorf("reading content: %w", err)
@@ -69,11 +69,6 @@ func (c *Client) SpaceBlobAdd(ctx context.Context, content io.Reader, space did.
 		},
 	}
 
-	pfs := make([]delegation.Proof, 0, len(c.Proofs()))
-	for _, del := range append(c.Proofs(), proofs...) {
-		pfs = append(pfs, delegation.FromDelegation(del))
-	}
-
 	res, fx, err := invokeAndExecute[spaceblobcap.AddCaveats, spaceblobcap.AddOk](
 		ctx,
 		c,
@@ -81,7 +76,6 @@ func (c *Client) SpaceBlobAdd(ctx context.Context, content io.Reader, space did.
 		space.String(),
 		caveats,
 		spaceblobcap.AddOkType(),
-		delegation.WithProof(pfs...),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invoking and executing `space/blob/add`: %w", err)

--- a/pkg/client/spaceblobadd_test.go
+++ b/pkg/client/spaceblobadd_test.go
@@ -47,7 +47,7 @@ import (
 	"github.com/storacha/guppy/pkg/client"
 )
 
-func TestBlobAdd(t *testing.T) {
+func TestSpaceBlobAdd(t *testing.T) {
 	space, err := ed25519signer.Generate()
 	if err != nil {
 		t.Fatal(err)
@@ -88,9 +88,11 @@ func TestBlobAdd(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	c.AddProofs(proof)
+
 	testBlob := bytes.NewReader([]byte("test"))
 
-	_, _, err = c.SpaceBlobAdd(testContext(t), testBlob, space.DID(), receiptsURL, proof)
+	_, _, err = c.SpaceBlobAdd(testContext(t), testBlob, space.DID(), receiptsURL)
 	require.NoError(t, err)
 }
 

--- a/pkg/client/uploadadd.go
+++ b/pkg/client/uploadadd.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ipld/go-ipld-prime"
 	uploadcap "github.com/storacha/go-libstoracha/capabilities/upload"
-	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/result"
 	"github.com/storacha/go-ucanto/did"
 )
@@ -23,12 +22,7 @@ import (
 // They won't be saved in the client, only used for this invocation.
 //
 // The `caveats` are caveats required to perform an `upload/add` invocation.
-func (c *Client) UploadAdd(ctx context.Context, space did.DID, root ipld.Link, shards []ipld.Link, proofs ...delegation.Delegation) (uploadcap.AddOk, error) {
-	pfs := make([]delegation.Proof, 0, len(c.Proofs()))
-	for _, del := range append(c.Proofs(), proofs...) {
-		pfs = append(pfs, delegation.FromDelegation(del))
-	}
-
+func (c *Client) UploadAdd(ctx context.Context, space did.DID, root ipld.Link, shards []ipld.Link) (uploadcap.AddOk, error) {
 	res, _, err := invokeAndExecute[uploadcap.AddCaveats, uploadcap.AddOk](
 		ctx,
 		c,
@@ -39,7 +33,6 @@ func (c *Client) UploadAdd(ctx context.Context, space did.DID, root ipld.Link, s
 			Shards: shards,
 		},
 		uploadcap.AddOkType(),
-		delegation.WithProof(pfs...),
 	)
 
 	if err != nil {

--- a/pkg/client/uploadlist.go
+++ b/pkg/client/uploadlist.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	uploadcap "github.com/storacha/go-libstoracha/capabilities/upload"
-	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/result"
 	"github.com/storacha/go-ucanto/did"
 )
@@ -21,12 +20,7 @@ import (
 //
 // The `proofs` are delegation proofs to use in addition to those in the client.
 // They won't be saved in the client, only used for this invocation.
-func (c *Client) UploadList(ctx context.Context, space did.DID, params uploadcap.ListCaveats, proofs ...delegation.Delegation) (uploadcap.ListOk, error) {
-	pfs := make([]delegation.Proof, 0, len(c.Proofs()))
-	for _, del := range append(c.Proofs(), proofs...) {
-		pfs = append(pfs, delegation.FromDelegation(del))
-	}
-
+func (c *Client) UploadList(ctx context.Context, space did.DID, params uploadcap.ListCaveats) (uploadcap.ListOk, error) {
 	res, _, err := invokeAndExecute[uploadcap.ListCaveats, uploadcap.ListOk](
 		ctx,
 		c,
@@ -34,7 +28,6 @@ func (c *Client) UploadList(ctx context.Context, space did.DID, params uploadcap
 		space.String(),
 		params,
 		uploadcap.ListOkType(),
-		delegation.WithProof(pfs...),
 	)
 
 	if err != nil {
@@ -47,5 +40,4 @@ func (c *Client) UploadList(ctx context.Context, space did.DID, params uploadcap
 	}
 
 	return addOk, nil
-
 }


### PR DESCRIPTION
Instead, add them to the client at the top and let the client use its proofs whenever it makes an invocation.

On the CLI, continue to not save proofs specified at the command line to the persisted agent state (by not enabling persistence for that client instance).








#### PR Dependency Tree


* **PR #47** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)