### PR TITLE
refactor(scans): move ids to types folder

### DIFF
--- a/pkg/preparation/dag/dags.go
+++ b/pkg/preparation/dag/dags.go
@@ -10,7 +10,6 @@ import (
 	"github.com/storacha/guppy/pkg/preparation/dag/file"
 	"github.com/storacha/guppy/pkg/preparation/dag/model"
 	"github.com/storacha/guppy/pkg/preparation/dag/visitor"
-	scansmodel "github.com/storacha/guppy/pkg/preparation/scans/model"
 	"github.com/storacha/guppy/pkg/preparation/types"
 )
 
@@ -26,7 +25,7 @@ type DAGAPI struct {
 	UnixFSParams UnixFSParamsFn
 }
 
-type FileAccessorFn func(ctx context.Context, fsEntryID scansmodel.FSEntryID) (fs.File, types.SourceID, string, error)
+type FileAccessorFn func(ctx context.Context, fsEntryID types.FSEntryID) (fs.File, types.SourceID, string, error)
 type UnixFSParamsFn func(ctx context.Context, uploadID types.UploadID) UnixFSParams
 
 // ExecuteDAGScan executes a dag scan on the given fs entry, creating a unix fs dag for the given file or directory.

--- a/pkg/preparation/dag/model/dagscan.go
+++ b/pkg/preparation/dag/model/dagscan.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/ipfs/go-cid"
-	scansmodel "github.com/storacha/guppy/pkg/preparation/scans/model"
 	"github.com/storacha/guppy/pkg/preparation/types"
 )
 
@@ -38,7 +37,7 @@ func validDAGScanState(state DAGScanState) bool {
 }
 
 type DAGScan interface {
-	FsEntryID() scansmodel.FSEntryID
+	FsEntryID() types.FSEntryID
 	UploadID() types.UploadID
 	CreatedAt() time.Time
 	UpdatedAt() time.Time
@@ -55,7 +54,7 @@ type DAGScan interface {
 }
 
 type dagScan struct {
-	fsEntryID    scansmodel.FSEntryID
+	fsEntryID    types.FSEntryID
 	uploadID     types.UploadID
 	createdAt    time.Time
 	updatedAt    time.Time
@@ -82,13 +81,12 @@ func validateDAGScan(d *dagScan) (*dagScan, error) {
 }
 
 // accessors
-func (d *dagScan) FsEntryID() scansmodel.FSEntryID {
+func (d *dagScan) FsEntryID() types.FSEntryID {
 	return d.fsEntryID
 }
 func (d *dagScan) UploadID() types.UploadID {
 	return d.uploadID
 }
-
 func (d *dagScan) CreatedAt() time.Time {
 	return d.createdAt
 }
@@ -187,7 +185,7 @@ func (d *DirectoryDAGScan) ChildrenCompleted() error {
 }
 
 // NewFileDAGScan creates a new FileDAGScan with the given fsEntryID.
-func NewFileDAGScan(fsEntryID scansmodel.FSEntryID) (*FileDAGScan, error) {
+func NewFileDAGScan(fsEntryID types.FSEntryID) (*FileDAGScan, error) {
 	fds := &FileDAGScan{
 		dagScan: dagScan{
 			fsEntryID: fsEntryID,
@@ -203,7 +201,7 @@ func NewFileDAGScan(fsEntryID scansmodel.FSEntryID) (*FileDAGScan, error) {
 }
 
 // NewDirectoryDAGScan creates a new DirectoryDAGScan with the given fsEntryID.
-func NewDirectoryDAGScan(fsEntryID scansmodel.FSEntryID) (*DirectoryDAGScan, error) {
+func NewDirectoryDAGScan(fsEntryID types.FSEntryID) (*DirectoryDAGScan, error) {
 	dds := &DirectoryDAGScan{
 		dagScan: dagScan{
 			fsEntryID: fsEntryID,
@@ -219,7 +217,7 @@ func NewDirectoryDAGScan(fsEntryID scansmodel.FSEntryID) (*DirectoryDAGScan, err
 }
 
 // DAGScanWriter is a function type for writing a DAGScan to the database.
-type DAGScanWriter func(kind string, fsEntryID scansmodel.FSEntryID, createdAt time.Time, updatedAt time.Time, errorMessage *string, state DAGScanState, cid *cid.Cid) error
+type DAGScanWriter func(kind string, fsEntryID types.FSEntryID, createdAt time.Time, updatedAt time.Time, errorMessage *string, state DAGScanState, cid *cid.Cid) error
 
 // WriteDAGScanToDatabase writes a DAGScan to the database using the provided writer function.
 func WriteDAGScanToDatabase(scan DAGScan, writer DAGScanWriter) error {
@@ -250,7 +248,7 @@ func WriteDAGScanToDatabase(scan DAGScan, writer DAGScanWriter) error {
 }
 
 // DAGScanScanner is a function type for scanning a DAGScan from the database.
-type DAGScanScanner func(kind *string, fsEntryID *scansmodel.FSEntryID, createdAt *time.Time, updatedAt *time.Time, errorMessage **string, state *DAGScanState, cid **cid.Cid) error
+type DAGScanScanner func(kind *string, fsEntryID *types.FSEntryID, createdAt *time.Time, updatedAt *time.Time, errorMessage **string, state *DAGScanState, cid **cid.Cid) error
 
 // ReadDAGScanFromDatabase reads a DAGScan from the database using the provided scanner function.
 func ReadDAGScanFromDatabase(scanner DAGScanScanner) (DAGScan, error) {

--- a/pkg/preparation/scans/model/fsentry.go
+++ b/pkg/preparation/scans/model/fsentry.go
@@ -9,10 +9,8 @@ import (
 	"github.com/storacha/guppy/pkg/preparation/types"
 )
 
-type FSEntryID = uuid.UUID
-
 type FSEntry interface {
-	ID() FSEntryID
+	ID() types.FSEntryID
 	// Path is the path within the datasource
 	Path() string
 	LastModified() time.Time
@@ -26,7 +24,7 @@ type FSEntry interface {
 }
 
 type fsEntry struct {
-	id           FSEntryID
+	id           types.FSEntryID
 	path         string
 	lastModified time.Time
 	mode         fs.FileMode
@@ -34,7 +32,7 @@ type fsEntry struct {
 	sourceID     types.SourceID // sourceID is the ID of the source this entry belongs to
 }
 
-func (f *fsEntry) ID() FSEntryID {
+func (f *fsEntry) ID() types.FSEntryID {
 	return f.id
 }
 
@@ -127,7 +125,7 @@ func NewDirectory(path string, lastModified time.Time, mode fs.FileMode, checksu
 	return directory, nil
 }
 
-type FSEntryWriter func(id FSEntryID, path string, lastModified time.Time, mode fs.FileMode, size uint64, checksum []byte, sourceID types.SourceID) error
+type FSEntryWriter func(id types.FSEntryID, path string, lastModified time.Time, mode fs.FileMode, size uint64, checksum []byte, sourceID types.SourceID) error
 
 func WriteFSEntryToDatabase(entry FSEntry, writer FSEntryWriter) error {
 	size := uint64(0)
@@ -137,7 +135,7 @@ func WriteFSEntryToDatabase(entry FSEntry, writer FSEntryWriter) error {
 	return writer(entry.ID(), entry.Path(), entry.LastModified(), entry.Mode(), size, entry.Checksum(), entry.SourceID())
 }
 
-type FSEntryScanner func(id *FSEntryID, path *string, lastModified *time.Time, mode *fs.FileMode, size *uint64, checksum *[]byte, sourceID *types.SourceID) error
+type FSEntryScanner func(id *types.FSEntryID, path *string, lastModified *time.Time, mode *fs.FileMode, size *uint64, checksum *[]byte, sourceID *types.SourceID) error
 
 func ReadFSEntryFromDatabase(scanner FSEntryScanner) (FSEntry, error) {
 	fsEntry := &fsEntry{}

--- a/pkg/preparation/scans/model/scan.go
+++ b/pkg/preparation/scans/model/scan.go
@@ -8,8 +8,7 @@ import (
 	"github.com/storacha/guppy/pkg/preparation/types"
 )
 
-type ScanID = uuid.UUID
-
+// ScanState represents the state of a scan.
 type ScanState string
 
 const (
@@ -36,10 +35,10 @@ func validScanState(state ScanState) bool {
 
 // Scan represents a single scan of a source, usually associated with an upload
 type Scan struct {
-	id           ScanID
+	id           types.ScanID
 	uploadID     types.UploadID
 	sourceID     types.SourceID
-	rootID       *FSEntryID // rootID is the ID of the root directory of the scan, if it has been completed
+	rootID       *types.FSEntryID // rootID is the ID of the root directory of the scan, if it has been completed
 	createdAt    time.Time
 	updatedAt    time.Time
 	errorMessage *string
@@ -71,7 +70,7 @@ func validateScan(s *Scan) (*Scan, error) {
 
 // accessors
 
-func (s *Scan) ID() ScanID {
+func (s *Scan) ID() types.ScanID {
 	return s.id
 }
 
@@ -105,7 +104,7 @@ func (s *Scan) HasRootID() bool {
 	return s.rootID != nil
 }
 
-func (s *Scan) RootID() FSEntryID {
+func (s *Scan) RootID() types.FSEntryID {
 	if s.rootID == nil {
 		return uuid.Nil // Return an empty FSEntryID if rootID is not set
 	}
@@ -122,7 +121,7 @@ func (s *Scan) Fail(errorMessage string) error {
 	return nil
 }
 
-func (s *Scan) Complete(rootID FSEntryID) error {
+func (s *Scan) Complete(rootID types.FSEntryID) error {
 	if s.state != ScanStateRunning {
 		return fmt.Errorf("cannot complete scan in state %s", s.state)
 	}
@@ -165,7 +164,7 @@ func NewScan(uploadID types.UploadID, sourceID types.SourceID) (*Scan, error) {
 	return validateScan(scan)
 }
 
-type ScanScanner func(id *ScanID, uploadID *types.UploadID, sourceID *types.SourceID, rootID **FSEntryID, createdAt *time.Time, updatedAt *time.Time, state *ScanState, errorMessage **string) error
+type ScanScanner func(id *types.ScanID, uploadID *types.UploadID, sourceID *types.SourceID, rootID **types.FSEntryID, createdAt *time.Time, updatedAt *time.Time, state *ScanState, errorMessage **string) error
 
 func ReadScanFromDatabase(scanner ScanScanner) (*Scan, error) {
 	scan := &Scan{}
@@ -176,7 +175,7 @@ func ReadScanFromDatabase(scanner ScanScanner) (*Scan, error) {
 	return validateScan(scan)
 }
 
-type ScanWriter func(id ScanID, uploadID types.UploadID, sourceID types.SourceID, rootID *FSEntryID, createdAt time.Time, updatedAt time.Time, state ScanState, errorMessage *string) error
+type ScanWriter func(id types.ScanID, uploadID types.UploadID, sourceID types.SourceID, rootID *types.FSEntryID, createdAt time.Time, updatedAt time.Time, state ScanState, errorMessage *string) error
 
 func WriteScanToDatabase(scan *Scan, writer ScanWriter) error {
 	return writer(scan.id, scan.uploadID, scan.sourceID, scan.rootID, scan.createdAt, scan.updatedAt, scan.state, scan.errorMessage)

--- a/pkg/preparation/scans/repo.go
+++ b/pkg/preparation/scans/repo.go
@@ -16,5 +16,5 @@ type Repo interface {
 	CreateDirectoryChildren(ctx context.Context, parent *model.Directory, children []model.FSEntry) error
 	DirectoryChildren(ctx context.Context, dir *model.Directory) ([]model.FSEntry, error)
 	UpdateScan(ctx context.Context, scan *model.Scan) error
-	GetFileByID(ctx context.Context, fileID model.FSEntryID) (*model.File, error)
+	GetFileByID(ctx context.Context, fileID types.FSEntryID) (*model.File, error)
 }

--- a/pkg/preparation/scans/scans.go
+++ b/pkg/preparation/scans/scans.go
@@ -90,7 +90,7 @@ func (s Scans) OpenFile(ctx context.Context, file *model.File) (fs.File, error) 
 }
 
 // GetFileByID retrieves a file by its ID from the repository, returning an error if not found.
-func (s Scans) GetFileByID(ctx context.Context, fileID model.FSEntryID) (*model.File, error) {
+func (s Scans) GetFileByID(ctx context.Context, fileID types.FSEntryID) (*model.File, error) {
 	file, err := s.Repo.GetFileByID(ctx, fileID)
 	if err != nil {
 		return nil, fmt.Errorf("getting file by ID %s: %w", fileID, err)
@@ -102,7 +102,7 @@ func (s Scans) GetFileByID(ctx context.Context, fileID model.FSEntryID) (*model.
 }
 
 // OpenFileByID retrieves a file by its ID and opens it for reading, returning an error if not found or if the file cannot be opened.
-func (s Scans) OpenFileByID(ctx context.Context, fileID model.FSEntryID) (fs.File, error) {
+func (s Scans) OpenFileByID(ctx context.Context, fileID types.FSEntryID) (fs.File, error) {
 	file, err := s.GetFileByID(ctx, fileID)
 	if err != nil {
 		return nil, err

--- a/pkg/preparation/types/id.go
+++ b/pkg/preparation/types/id.go
@@ -7,3 +7,9 @@ type SourceID = uuid.UUID
 
 // UploadID is an alias for uuid.UUID and uniquely identifies an upload.
 type UploadID = uuid.UUID
+
+// ScanID is an alias for uuid.UUID and uniquely identifies a scan.
+type ScanID = uuid.UUID
+
+// FSEntryID is an alias for uuid.UUID and uniquely identifies a filesystem entry.
+type FSEntryID = uuid.UUID


### PR DESCRIPTION
# Goals

Since looks like we're gonna be unmerged for a bit, going to submit PRs. This finishes putting the ids in the types folders








#### PR Dependency Tree


* **PR #51** 👈
  * **PR #52**
    * **PR #53**
      * **PR #54**
        * **PR #57**
          * **PR #58**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)