### PR TITLE
refactor(uploads): reorganize uploads

### DIFF
--- a/pkg/preparation/configurations/configurations.go
+++ b/pkg/preparation/configurations/configurations.go
@@ -1,0 +1,12 @@
+package configurations
+
+import "github.com/storacha/guppy/pkg/preparation/configurations/model"
+
+type ConfigurationsAPI struct {
+	repo Repo
+}
+
+// CreateConfiguration creates a new configuration with the given name and options.
+func (u ConfigurationsAPI) CreateConfiguration(name string, options ...model.ConfigurationOption) (*model.Configuration, error) {
+	return u.repo.CreateConfiguration(name, options...)
+}

--- a/pkg/preparation/configurations/model/configuration.go
+++ b/pkg/preparation/configurations/model/configuration.go
@@ -1,0 +1,213 @@
+package model
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/storacha/guppy/pkg/preparation/types"
+)
+
+// MaxShardSize is the maximum allowed size for a shard, set to 4GB
+const MaxShardSize = 4 << 30
+
+// MinShardSize is the minimum allowed size for a shard, set to 128 bytes
+const MinShardSize = 128
+
+// DefaultShardSize is the default size for a shard, set to 512MB
+const DefaultShardSize = 512 << 20 // default shard size = 512MB
+
+// MaxBlockSize is the maximum size of a block, set to 2MB
+const MaxBlockSize = 2 << 20 // 2MB
+// MinBlockSize is the minimum size of a block, set to 64KB
+const MinBlockSize = 64 << 10 // 64KB
+// DefaultBlockSize is the default size of a block, set to 1MB
+const DefaultBlockSize = 1 << 20 // default block size = 1MB
+
+// MaxLinksPerNode is the maximum number of links per node, set to 2048
+const MaxLinksPerNode = 2048 // maximum number of links per node
+// MinLinksPerNode is the minimum number of links per node, set to 2
+const MinLinksPerNode = 2 // minimum number of links per node
+// DefaultLinksPerNode is the default number of links per node, set to 1024
+const DefaultLinksPerNode = 1024 // default links per node = 1024
+
+// MaxUseHAMTDirectorySize is the maximum size for switching to a HAMT directory, set to 4096
+const MaxUseHAMTDirectorySize = 4096
+
+// MinUseHAMTDirectorySize is the minimum size for switching to a HAMT directory, set to 128
+const MinUseHAMTDirectorySize = 128
+
+// DefaultUseHAMTDirectorySize is the default size for switching to a HAMT directory, set to 1024
+const DefaultUseHAMTDirectorySize = 1024 // default use HAMT directory size = 1024
+
+// ErrBlockSizeTooLarge indicates that the block size is larger than the maximum allowed size.
+var ErrBlockSizeTooLarge = errors.New("Block size must be less than 2MB")
+
+// ErrBlockSizeTooSmall indicates that the block size is smaller than the minimum allowed size.
+var ErrBlockSizeTooSmall = errors.New("Block size must be at least 64KB")
+
+// ErrLinksPerNodeTooLarge indicates that the number of links per node is larger than the maximum allowed.
+var ErrLinksPerNodeTooLarge = errors.New("Links per node must be less than 2048")
+
+// ErrLinksPerNodeTooSmall indicates that the number of links per node is smaller than the minimum allowed.
+var ErrLinksPerNodeTooSmall = errors.New("Links per node must be at least 2")
+
+// ErrShardSizeTooLarge indicates that the shard size is larger than the maximum allowed size.
+var ErrShardSizeTooLarge = errors.New("Shard size must be less than 4GB")
+
+// ErrShardSizeTooSmall indicates that the shard size is smaller than the minimum allowed size.
+var ErrShardSizeTooSmall = errors.New("Shard size must be at least 128 bytes")
+
+// ErrUseHAMTDirectorySizeTooLarge indicates that the size for switching to a HAMT directory is larger than the maximum allowed.
+var ErrUseHAMTDirectorySizeTooLarge = errors.New("Use HAMT directory size must be less than 4096")
+
+// ErrUseHAMTDirectorySizeTooSmall indicates that the size for switching to a HAMT directory is smaller than the minimum allowed.
+var ErrUseHAMTDirectorySizeTooSmall = errors.New("Use HAMT directory size must be at least 128")
+
+// Configuration represents the configuration for an upload or uploads
+type Configuration struct {
+	id        types.ConfigurationID
+	name      string
+	createdAt time.Time
+
+	blockSize            uint64
+	linksPerNode         uint64
+	shardSize            uint64 // blob size in bytes
+	useHAMTDirectorySize uint64 // size in bytes for switching to a HAMT directory
+}
+
+// ID returns the unique identifier of the configuration.
+func (u *Configuration) ID() types.ConfigurationID {
+	return u.id
+}
+
+// Name returns the name of the configuration.
+func (u *Configuration) Name() string {
+	return u.name
+}
+
+// CreatedAt returns the creation time of the configuration.
+func (u *Configuration) CreatedAt() time.Time {
+	return u.createdAt
+}
+
+// ShardSize returns the size of each shard in bytes.
+func (u *Configuration) ShardSize() uint64 {
+	return u.shardSize
+}
+
+// BlockSize returns the size of each block in bytes.
+func (u *Configuration) BlockSize() uint64 {
+	return u.blockSize
+}
+
+// LinksPerNode returns the number of links per node.
+func (u *Configuration) LinksPerNode() uint64 {
+	return u.linksPerNode
+}
+
+// UseHAMTDirectorySize returns the size for switching to a HAMT directory.
+func (u *Configuration) UseHAMTDirectorySize() uint64 {
+	return u.useHAMTDirectorySize
+}
+
+// ConfigurationOption is a functional option type for configuring a Configuration.
+type ConfigurationOption func(*Configuration) error
+
+// WithShardSize sets the size of each shard in bytes for the configuration.
+// The shard size must be between 128 bytes and 4GB.
+func WithShardSize(shardSize uint64) ConfigurationOption {
+	return func(u *Configuration) error {
+		u.shardSize = shardSize
+		return nil
+	}
+}
+
+// WithBlockSize sets the size of each block in bytes for the configuration.
+func WithBlockSize(blockSize uint64) ConfigurationOption {
+	return func(u *Configuration) error {
+		u.blockSize = blockSize
+		return nil
+	}
+}
+
+// WithLinksPerNode sets the number of links per node for the configuration.
+func WithLinksPerNode(linksPerNode uint64) ConfigurationOption {
+	return func(u *Configuration) error {
+		u.linksPerNode = linksPerNode
+		return nil
+	}
+}
+
+// WithUseHAMTDirectorySize sets the size for switching to a HAMT directory.
+func WithUseHAMTDirectorySize(useHAMTDirectorySize uint64) ConfigurationOption {
+	return func(u *Configuration) error {
+		u.useHAMTDirectorySize = useHAMTDirectorySize
+		return nil
+	}
+}
+
+// validateConfiguration checks if the configuration is valid.
+func validateConfiguration(u *Configuration) (*Configuration, error) {
+	if u.id == uuid.Nil {
+		return nil, types.ErrEmpty{Field: "id"}
+	}
+	if u.name == "" {
+		return nil, types.ErrEmpty{Field: "name"}
+	}
+	if u.shardSize >= MaxShardSize {
+		return nil, ErrShardSizeTooLarge
+	}
+	if u.shardSize < MinShardSize {
+		return nil, ErrShardSizeTooSmall
+	}
+	if u.blockSize >= MaxBlockSize {
+		return nil, ErrBlockSizeTooLarge
+	}
+	if u.blockSize < MinBlockSize {
+		return nil, ErrBlockSizeTooSmall
+	}
+	if u.linksPerNode > MaxLinksPerNode {
+		return nil, ErrLinksPerNodeTooLarge
+	}
+	if u.linksPerNode < MinLinksPerNode {
+		return nil, ErrLinksPerNodeTooSmall
+	}
+	if u.useHAMTDirectorySize > MaxUseHAMTDirectorySize {
+		return nil, ErrUseHAMTDirectorySizeTooLarge
+	}
+	if u.useHAMTDirectorySize < MinUseHAMTDirectorySize {
+		return nil, ErrUseHAMTDirectorySizeTooSmall
+	}
+	return u, nil
+}
+
+// NewConfiguration creates a new Configuration instance with the given name and options.
+func NewConfiguration(name string, opts ...ConfigurationOption) (*Configuration, error) {
+	u := &Configuration{
+		id:        uuid.New(),
+		name:      name,
+		shardSize: DefaultShardSize, // default shard size
+		createdAt: time.Now(),
+	}
+	for _, opt := range opts {
+		if err := opt(u); err != nil {
+			return nil, err
+		}
+	}
+	return validateConfiguration(u)
+}
+
+// ConfigurationRowScanner is a function type for scanning a configuration row from the database.
+type ConfigurationRowScanner func(id *types.ConfigurationID, name *string, createdAt *time.Time, shardSize *uint64, blockSize *uint64, linksPerNode *uint64, useHAMTDirectorySize *uint64) error
+
+// ReadConfigurationFromDatabase reads a Configuration from the database using the provided scanner function.
+func ReadConfigurationFromDatabase(scanner ConfigurationRowScanner) (*Configuration, error) {
+	configuration := &Configuration{}
+	err := scanner(&configuration.id, &configuration.name, &configuration.createdAt, &configuration.shardSize, &configuration.blockSize, &configuration.linksPerNode, &configuration.useHAMTDirectorySize)
+	if err != nil {
+		return nil, fmt.Errorf("reading configuration from database: %w", err)
+	}
+	return validateConfiguration(configuration)
+}

--- a/pkg/preparation/configurations/repo.go
+++ b/pkg/preparation/configurations/repo.go
@@ -1,0 +1,25 @@
+package configurations
+
+import (
+	"github.com/storacha/guppy/pkg/preparation/configurations/model"
+	"github.com/storacha/guppy/pkg/preparation/types"
+)
+
+type Repo interface {
+	// GetConfigurationByID retrieves a configuration by its unique ID.
+	GetConfigurationByID(configID types.ConfigurationID) (*model.Configuration, error)
+	// GetConfigurationByName retrieves a configuration by its name.
+	GetConfigurationByName(name string) (*model.Configuration, error)
+	// CreateConfiguration creates a new configuration with the given name and options.
+	CreateConfiguration(name string, options ...model.ConfigurationOption) (*model.Configuration, error)
+	// DeleteConfiguration deletes the configuration by its unique ID.
+	DeleteConfiguration(configID types.ConfigurationID) error
+	// ListConfigurations lists all configurations in the repository.
+	ListConfigurations() ([]*model.Configuration, error)
+	// AddSourceToConfiguration creates a new configuration source mapping with the given configuration ID and source ID.
+	AddSourceToConfiguration(configID types.ConfigurationID, sourceID types.SourceID) error
+	// RemoveSourceFromConfiguration removes the configuration source mapping by configuration ID and source ID.
+	RemoveSourceFromConfiguration(configID types.ConfigurationID, sourceID types.SourceID) error
+	// ListConfigurationSources lists all configuration sources for the given configuration ID.
+	ListConfigurationSources(configID types.ConfigurationID) ([]types.SourceID, error)
+}

--- a/pkg/preparation/preparation.go
+++ b/pkg/preparation/preparation.go
@@ -1,0 +1,14 @@
+package preparation
+
+// HACKME: This package is a placeholder for the preparation package.
+
+// Intended stack:
+// initialize a DB
+// initialize a sqlrepo.Repo
+// initialize configurations.Configurations
+// initialize sources.Sources
+// initialize uploads.Uploads - ConfigurationSourcesLookup = Configurations.GetSourceIDsForConfiguration
+// initialize scans.Scans - SourceAccessor = Sources.GetSourceByID, UploadSourceLookup = Uploads.GetSourceIDForUploadID
+// initialize dagscans.DAGScans - FileAccesor = Scans.OpenFileByID, UnixFSParams = Configurations.GetConfigurationByID (TBD)
+
+// put execution code below...

--- a/pkg/preparation/scans/repo.go
+++ b/pkg/preparation/scans/repo.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Repo interface {
-	CreateScan(ctx context.Context, sourceID types.SourceID, uploadID types.UploadID) (*model.Scan, error)
+	CreateScan(ctx context.Context, uploadID types.UploadID) (*model.Scan, error)
 	FindOrCreateFile(ctx context.Context, path string, lastModified time.Time, mode fs.FileMode, size uint64, checksum []byte, sourceID types.SourceID) (*model.File, bool, error)
 	FindOrCreateDirectory(ctx context.Context, path string, lastModified time.Time, mode fs.FileMode, checksum []byte, sourceID types.SourceID) (*model.Directory, bool, error)
 	CreateDirectoryChildren(ctx context.Context, parent *model.Directory, children []model.FSEntry) error

--- a/pkg/preparation/sources/model/source.go
+++ b/pkg/preparation/sources/model/source.go
@@ -21,7 +21,7 @@ const (
 
 // Source represents a data source.
 type Source struct {
-	id               uuid.UUID
+	id               types.SourceID
 	name             string
 	createdAt        time.Time
 	updatedAt        time.Time
@@ -31,7 +31,7 @@ type Source struct {
 }
 
 // ID returns the unique identifier of the source.
-func (s *Source) ID() uuid.UUID {
+func (s *Source) ID() types.SourceID {
 	return s.id
 }
 
@@ -99,7 +99,7 @@ func NewSource(name string, path string, opts ...SourceOption) (*Source, error) 
 }
 
 // SourceRowScanner is a function type for scanning a source row from the database.
-type SourceRowScanner func(id *uuid.UUID, name *string, createdAt *time.Time, updatedAt *time.Time, kind *SourceKind, path *string, connectionParams *ConnectionParams) error
+type SourceRowScanner func(id *types.SourceID, name *string, createdAt *time.Time, updatedAt *time.Time, kind *SourceKind, path *string, connectionParams *ConnectionParams) error
 
 // ReadSourceFromDatabase reads a Source from the database using the provided scanner function.
 func ReadSourceFromDatabase(scanner SourceRowScanner) (*Source, error) {

--- a/pkg/preparation/sqlrepo/schema.sql
+++ b/pkg/preparation/sqlrepo/schema.sql
@@ -1,0 +1,122 @@
+-- enable foreign key constraints
+PRAGMA foreign_keys = ON;
+-- enable write ahead logging
+PRAGMA journal_mode = WAL;
+
+-- DROP TABLE IF EXISTS sources CASCADE;
+-- DROP TABLE IF EXISTS configurations CASCADE;
+-- DROP TABLE IF EXISTS configuration_sources;
+-- DROP TABLE IF EXISTS uploads CASCADE;
+-- DROP TABLE IF EXISTS scans CASCADE;
+-- DROP TABLE IF EXISTS fs_entries CASCADE;
+-- DROP TABLE IF EXISTS directory_children;
+-- DROP TABLE IF EXISTS dag_scans CASCADE;
+-- DROP TABLE IF EXISTS nodes CASCADE;
+-- DROP TABLE IF EXISTS links;
+CREATE TABLE IF NOT EXISTS sources (
+  id BLOB PRIMARY KEY,
+  name TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  path TEXT NOT NULL,
+  connection_params BLOB,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS configurations (
+  id BLOB PRIMARY KEY,
+  name TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  block_size INTEGER NOT NULL,
+  links_per_node INTEGER NOT NULL,
+  shard_size INTEGER NOT NULL,
+  use_hamt_directory_size INTEGER NOT NULL,
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS configuration_sources (
+  source_id BLOB NOT NULL,
+  configuration_id BLOB NOT NULL,
+  FOREIGN KEY (source_id) REFERENCES sources(id),
+  FOREIGN KEY (configuration_id) REFERENCES configurations(id),
+  PRIMARY KEY (source_id, configuration_id) 
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS uploads (
+  id BLOB PRIMARY KEY,
+  configuration_id BLOB NOT NULL,
+  source_id BLOB NOT NULL,
+  created_at TEXT NOT NULL
+  FOREIGN KEY (configuration_id) REFERENCES configurations(id),
+  FOREIGN KEY (source_id) REFERENCES sources(id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS scans (
+  id BLOB PRIMARY KEY,
+  upload_id BLOB NOT NULL,
+  created_at TEXT NOT NULL,
+  root_id BLOB,
+  updated_at TEXT NOT NULL,
+  error_message TEXT,
+  state TEXT NOT NULL
+  FOREIGN KEY (upload_id) REFERENCES uploads(id),
+  FOREIGN KEY (root_id) REFERENCES fs_entries(id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS fs_entries (
+  id BLOB PRIMARY KEY,
+  source_id BLOB NOT NULL,
+  path TEXT NOT NULL,
+  last_modified TEXT NOT NULL,
+  mode INTEGER NOT NULL,
+  size INTEGER NOT NULL,
+  checksum BLOB,
+  FOREIGN KEY (source_id) REFERENCES sources(id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS directory_children (
+  directory_id BLOB NOT NULL,
+  child_id BLOB NOT NULL,
+  FOREIGN KEY (directory_id) REFERENCES fs_entries(id),
+  FOREIGN KEY (child_id) REFERENCES fs_entries(id),
+  PRIMARY KEY (directory_id, child_id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS dag_scans (
+  fs_entry_id BLOB NOT NULL PRIMARY KEY,
+  upload_id BLOB NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  error_message TEXT,
+  state TEXT NOT NULL,
+  cid BLOB,
+  kind TEXT NOT NULL CHECK (
+      kind IN (
+      'file',
+      'directory',
+    )
+  ),
+  FOREIGN KEY (fs_entry_id) REFERENCES fs_entries(id),
+  FOREIGN KEY (upload_id) REFERENCES uploads(id),
+  FOREIGN KEY (cid) REFERENCES nodes(cid)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS nodes (
+  cid BLOB PRIMARY KEY,
+  size INTEGER NOT NULL,
+  ufsddata BLOB NOT NULL,
+  path TEXT NOT NULL,
+  source_id BLOB NOT NULL,
+  offset INTEGER NOT NULL,
+  FOREIGN KEY (source_id) REFERENCES sources(id)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS links (
+  name TEXT NOT NULL,
+  t_size INTEGER NOT NULL,
+  hash CID NOT NULL,
+  parent_id CID NOT NULL,
+  order INTEGER NOT NULL,
+  FOREIGN KEY (parent_id) REFERENCES nodes(cid),
+  FOREIGN KEY (hash) REFERENCES nodes(cid),
+  PRIMARY KEY (name, t_size, hash, parent_id, order)
+) STRICT;

--- a/pkg/preparation/types/id.go
+++ b/pkg/preparation/types/id.go
@@ -5,6 +5,9 @@ import "github.com/google/uuid"
 // SourceID is an alias for uuid.UUID and uniquely identifies a source.
 type SourceID = uuid.UUID
 
+// ConfigurationID is an alias for uuid.UUID and uniquely identifies a configuration.
+type ConfigurationID = uuid.UUID
+
 // UploadID is an alias for uuid.UUID and uniquely identifies an upload.
 type UploadID = uuid.UUID
 

--- a/pkg/preparation/uploads/repo.go
+++ b/pkg/preparation/uploads/repo.go
@@ -1,26 +1,17 @@
 package uploads
 
 import (
-	"github.com/storacha/guppy/pkg/preparation/sources/model"
+	"context"
+
 	"github.com/storacha/guppy/pkg/preparation/types"
-	uploadmodel "github.com/storacha/guppy/pkg/preparation/uploads/model"
+	"github.com/storacha/guppy/pkg/preparation/uploads/model"
 )
 
 type Repo interface {
 	// GetUploadByID retrieves an upload by its unique ID.
-	GetUploadByID(uploadID types.UploadID) (*uploadmodel.Upload, error)
-	// GetUploadByName retrieves an upload by its name.
-	GetUploadByName(name string) (*uploadmodel.Upload, error)
-	// CreateUpload creates a new upload with the given name and options.
-	CreateUpload(name string, options ...uploadmodel.UploadOption) (*uploadmodel.Upload, error)
-	// AddSourceToUpload creates a new upload source mapping with the given upload ID and source ID.
-	AddSourceToUpload(uploadID types.UploadID, sourceID types.SourceID) error
-	// RemoveSourceFromUpload removes the upload source mapping by upload ID and source ID.
-	RemoveSourceFromUpload(uploadID types.UploadID, sourceID types.SourceID) error
-	// ListUploadSources lists all upload sources for the given upload ID.
-	ListUploadSources(uploadID types.UploadID) ([]*model.Source, error)
-	// DeleteUpload deletes the upload by its unique ID.
-	DeleteUpload(uploadID types.UploadID) error
-	// ListUploads lists all uploads in the repository.
-	ListUploads() ([]*uploadmodel.Upload, error)
+	GetUploadByID(ctx context.Context, uploadID types.UploadID) (*model.Upload, error)
+	// GetSourceIDForUploadID retrieves the source ID associated with a given upload ID.
+	GetSourceIDForUploadID(ctx context.Context, uploadID types.UploadID) (types.SourceID, error)
+	// CreateUploads creates uploads for a given configuration
+	CreateUploads(ctx context.Context, configurationID types.ConfigurationID, sourceIDs []types.SourceID) ([]*model.Upload, error)
 }

--- a/pkg/preparation/uploads/uploads.go
+++ b/pkg/preparation/uploads/uploads.go
@@ -1,12 +1,39 @@
 package uploads
 
-import "github.com/storacha/guppy/pkg/preparation/uploads/model"
+import (
+	"context"
 
-type UploadsAPI struct {
-	repo Repo
+	"github.com/storacha/guppy/pkg/preparation/types"
+	"github.com/storacha/guppy/pkg/preparation/uploads/model"
+)
+
+type Uploads struct {
+	repo                       Repo
+	ConfigurationSourcesLookup ConfigurationSourcesLookupFn
 }
 
-// CreateUpload creates a new upload with the given name and options.
-func (u UploadsAPI) CreateUpload(name string, options ...model.UploadOption) (*model.Upload, error) {
-	return u.repo.CreateUpload(name, options...)
+type ConfigurationSourcesLookupFn func(ctx context.Context, configurationID types.ConfigurationID) ([]types.SourceID, error)
+
+// CreateUploads creates uploads for a given configuration and its associated sources.
+func (u Uploads) CreateUploads(ctx context.Context, configurationID types.ConfigurationID) ([]*model.Upload, error) {
+	sources, err := u.ConfigurationSourcesLookup(ctx, configurationID)
+	if err != nil {
+		return nil, err
+	}
+
+	uploads, err := u.repo.CreateUploads(ctx, configurationID, sources)
+	if err != nil {
+		return nil, err
+	}
+	return uploads, nil
+}
+
+// GetSourceIDForUploadID retrieves the source ID associated with a given upload ID.
+func (u Uploads) GetSourceIDForUploadID(ctx context.Context, uploadID types.UploadID) (types.SourceID, error) {
+	return u.repo.GetSourceIDForUploadID(ctx, uploadID)
+}
+
+// GetUploadByID retrieves an upload by its unique ID.
+func (u Uploads) GetUploadByID(ctx context.Context, uploadID types.UploadID) (*model.Upload, error) {
+	return u.repo.GetUploadByID(ctx, uploadID)
 }


### PR DESCRIPTION
# Goals

reorganizes uploads to match the storacha domain entity "Upload" which represents a single successful upload of a DAG

# Implementation

- where a scan = 1 filesystem scan, and upload equals as many filesystem scans, dag assembly attempts, and shard uploads as are needed to successfully upload the full dag from a source
- configuration = a set of parameters that apply to multiple sources and or uploads
- configuration_sources = connect sources to configurations, so I can say "set of uploads for every source attached to this configuration" -- not 100% sure if this is needed
- also adds a schema.sql








#### PR Dependency Tree


* **PR #52** 👈
  * **PR #53**
    * **PR #54**
      * **PR #57**
        * **PR #58**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)