### PR TITLE
chore: Add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-@hannahhoward
-@Peeja
+*	@hannahhoward @Peeja @alanshaw @volmedo


### PR DESCRIPTION
This seems correct for the moment? I think we're the only ones focused on this repo at the moment.


#### PR Dependency Tree


* **PR #56** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)