### PR TITLE
refactor: More "Cancell{ed,ing}" → one "l"

### DIFF
--- a/pkg/client/pollclaim.go
+++ b/pkg/client/pollclaim.go
@@ -38,7 +38,7 @@ func (c *Client) pollClaimWithTicker(ctx context.Context, authOk access.Authoriz
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("context cancelled before delegations could be claimed: %w", ctx.Err())
+			return nil, fmt.Errorf("context canceled before delegations could be claimed: %w", ctx.Err())
 		case <-tickChan:
 			dels, err := c.ClaimAccess(ctx)
 			if err != nil {

--- a/pkg/client/pollclaim_test.go
+++ b/pkg/client/pollclaim_test.go
@@ -141,14 +141,14 @@ func TestPollClaim(t *testing.T) {
 
 		claimedDels, err := result.Unwrap(<-resultChan)
 
-		require.Empty(t, claimedDels, "expected no delegations to be claimed due to context cancellation")
+		require.Empty(t, claimedDels, "expected no delegations to be claimed due to context cancelation")
 		require.ErrorContains(t, err, "Something went wrong!", "expected error from PollClaim")
 
 		_, ok := <-resultChan
-		require.False(t, ok, "expected result channel to be closed after context cancellation")
+		require.False(t, ok, "expected result channel to be closed after context cancelation")
 	})
 
-	t.Run("respects the context's cancellation", func(t *testing.T) {
+	t.Run("respects the context's cancelation", func(t *testing.T) {
 		// A channel that will never tick
 		tickChan := make(chan time.Time)
 		ctx, cancel := context.WithCancel(testContext(t))
@@ -163,10 +163,10 @@ func TestPollClaim(t *testing.T) {
 
 		claimedDels, err := result.Unwrap(<-resultChan)
 
-		require.Empty(t, claimedDels, "expected no delegations to be claimed due to context cancellation")
-		require.ErrorContains(t, err, "context canceled", "expected context cancellation error from PollClaim")
+		require.Empty(t, claimedDels, "expected no delegations to be claimed due to context cancelation")
+		require.ErrorContains(t, err, "context canceled", "expected context cancelation error from PollClaim")
 
 		_, ok := <-resultChan
-		require.False(t, ok, "expected result channel to be closed after context cancellation")
+		require.False(t, ok, "expected result channel to be closed after context cancelation")
 	})
 }

--- a/pkg/preparation/dag/dags.go
+++ b/pkg/preparation/dag/dags.go
@@ -55,10 +55,10 @@ func (d DAGAPI) UploadDAGScanWorker(ctx context.Context, work <-chan struct{}, u
 	}
 }
 
-// RestartScansForUpload restarts all cancelled or running DAG scans for the given upload ID.
+// RestartScansForUpload restarts all canceled or running DAG scans for the given upload ID.
 func (d DAGAPI) RestartScansForUpload(ctx context.Context, uploadID types.UploadID) error {
-	// restart all cancelled/running dag scans
-	restartableDagScans, err := d.Repo.DAGScansForUploadByStatus(ctx, uploadID, model.DAGScanStateCancelled, model.DAGScanStateRunning)
+	// restart all canceled/running dag scans
+	restartableDagScans, err := d.Repo.DAGScansForUploadByStatus(ctx, uploadID, model.DAGScanStateCanceled, model.DAGScanStateRunning)
 	if err != nil {
 		return fmt.Errorf("getting restartable dag scans for upload %s: %w", uploadID, err)
 	}

--- a/pkg/preparation/dag/model/dagscan.go
+++ b/pkg/preparation/dag/model/dagscan.go
@@ -23,13 +23,13 @@ const (
 	DAGScanStateCompleted DAGScanState = "completed"
 	// DAGScanStateFailed indicates that the file system entry has failed.
 	DAGScanStateFailed DAGScanState = "failed"
-	// DAGScanStateCancelled indicates that the file system entry has been cancelled.
-	DAGScanStateCancelled DAGScanState = "cancelled"
+	// DAGScanStateCanceled indicates that the file system entry has been canceled.
+	DAGScanStateCanceled DAGScanState = "canceled"
 )
 
 func validDAGScanState(state DAGScanState) bool {
 	switch state {
-	case DAGScanStateAwaitingChildren, DAGScanStatePending, DAGScanStateRunning, DAGScanStateCompleted, DAGScanStateFailed, DAGScanStateCancelled:
+	case DAGScanStateAwaitingChildren, DAGScanStatePending, DAGScanStateRunning, DAGScanStateCompleted, DAGScanStateFailed, DAGScanStateCanceled:
 		return true
 	default:
 		return false
@@ -37,7 +37,7 @@ func validDAGScanState(state DAGScanState) bool {
 }
 
 func TerminatedState(state DAGScanState) bool {
-	return state == DAGScanStateCompleted || state == DAGScanStateFailed || state == DAGScanStateCancelled
+	return state == DAGScanStateCompleted || state == DAGScanStateFailed || state == DAGScanStateCanceled
 }
 
 type DAGScan interface {
@@ -141,7 +141,7 @@ func (d *dagScan) Cancel() error {
 	if TerminatedState(d.state) {
 		return fmt.Errorf("cannot cancel dag scan in state %s", d.state)
 	}
-	d.state = DAGScanStateCancelled
+	d.state = DAGScanStateCanceled
 	d.errorMessage = nil
 	d.updatedAt = time.Now()
 	return nil
@@ -158,7 +158,7 @@ func (d *dagScan) Start() error {
 }
 
 func (d *dagScan) Restart() error {
-	if d.state != DAGScanStateRunning && d.state != DAGScanStateCancelled {
+	if d.state != DAGScanStateRunning && d.state != DAGScanStateCanceled {
 		return fmt.Errorf("cannot restart dag scan in state %s", d.state)
 	}
 	d.state = DAGScanStatePending

--- a/pkg/preparation/scans/model/scan.go
+++ b/pkg/preparation/scans/model/scan.go
@@ -20,8 +20,8 @@ const (
 	ScanStateCompleted ScanState = "completed"
 	// ScanStateFailed indicates that the scan has failed.
 	ScanStateFailed ScanState = "failed"
-	// ScanStateCanceled indicates that the scan has been cancelled.
-	ScanStateCanceled ScanState = "cancelled"
+	// ScanStateCanceled indicates that the scan has been canceled.
+	ScanStateCanceled ScanState = "canceled"
 )
 
 func validScanState(state ScanState) bool {

--- a/pkg/preparation/scans/scans_test.go
+++ b/pkg/preparation/scans/scans_test.go
@@ -112,7 +112,7 @@ func TestExecuteScan(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		scan, scansProcess := newScanAndProcess(t)
 		scansProcess.WalkerFn = func(fsys fs.FS, root string, visitor walker.FSVisitor) (model.FSEntry, error) {
-			cancel() // Cancel the context to simulate a cancellation
+			cancel() // Cancel the context to simulate a cancelation
 			return nil, ctx.Err()
 		}
 

--- a/pkg/preparation/sqlrepo/schema.sql
+++ b/pkg/preparation/sqlrepo/schema.sql
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS uploads (
       'uploading',
       'completed',
       'failed',
-      'cancelled'
+      'canceled'
     )
   ),
   error_message TEXT,

--- a/pkg/preparation/sqlrepo/uploads.go
+++ b/pkg/preparation/sqlrepo/uploads.go
@@ -104,7 +104,7 @@ func (r *repo) CIDForFSEntry(ctx context.Context, fsEntryID types.FSEntryID) (ci
 		switch ds.State() {
 		case dagmodel.DAGScanStateFailed:
 			return cid.Undef, nil
-		case dagmodel.DAGScanStateCancelled:
+		case dagmodel.DAGScanStateCanceled:
 			return cid.Undef, nil
 		default:
 			return cid.Undef, fmt.Errorf("DAG scan for fs_entry_id %s is not completed, current state: %s", fsEntryID, ds.State())

--- a/pkg/preparation/uploads/model/upload.go
+++ b/pkg/preparation/uploads/model/upload.go
@@ -27,13 +27,13 @@ const (
 	UploadStateCompleted UploadState = "completed"
 	// UploadStateFailed indicates that the upload has failed.
 	UploadStateFailed UploadState = "failed"
-	// UploadStateCancelled indicates that the upload has been cancelled.
-	UploadStateCancelled UploadState = "cancelled"
+	// UploadStateCanceled indicates that the upload has been canceled.
+	UploadStateCanceled UploadState = "canceled"
 )
 
 func validUploadState(state UploadState) bool {
 	switch state {
-	case UploadStatePending, UploadStateScanning, UploadStateGeneratingDAG, UploadStateSharding, UploadStateUploading, UploadStateCompleted, UploadStateFailed, UploadStateCancelled:
+	case UploadStatePending, UploadStateScanning, UploadStateGeneratingDAG, UploadStateSharding, UploadStateUploading, UploadStateCompleted, UploadStateFailed, UploadStateCanceled:
 		return true
 	default:
 		return false
@@ -41,11 +41,11 @@ func validUploadState(state UploadState) bool {
 }
 
 func TerminatedState(state UploadState) bool {
-	return state == UploadStateCompleted || state == UploadStateFailed || state == UploadStateCancelled
+	return state == UploadStateCompleted || state == UploadStateFailed || state == UploadStateCanceled
 }
 
 func RestartableState(state UploadState) bool {
-	return state == UploadStateScanning || state == UploadStateGeneratingDAG || state == UploadStateSharding || state == UploadStateUploading || state == UploadStateCancelled
+	return state == UploadStateScanning || state == UploadStateGeneratingDAG || state == UploadStateSharding || state == UploadStateUploading || state == UploadStateCanceled
 }
 
 // Upload represents the process of full or partial upload of data from a source, eventually represented as an upload in storacha.
@@ -129,7 +129,7 @@ func (u *Upload) Cancel() error {
 	if TerminatedState(u.state) {
 		return fmt.Errorf("cannot cancel upload in state %s", u.state)
 	}
-	u.state = UploadStateCancelled
+	u.state = UploadStateCanceled
 	u.errorMessage = nil
 	u.updatedAt = time.Now()
 	return nil

--- a/pkg/preparation/uploads/uploads.go
+++ b/pkg/preparation/uploads/uploads.go
@@ -149,7 +149,7 @@ func (u Uploads) ExecuteUpload(ctx context.Context, upload *model.Upload, opts .
 			}
 		case model.UploadStateFailed:
 			return fmt.Errorf("upload failed: %w", upload.Error())
-		case model.UploadStateCancelled:
+		case model.UploadStateCanceled:
 			return context.Canceled
 		case model.UploadStateCompleted:
 			// upload is complete, no further action needed


### PR DESCRIPTION
Just making sure we stay consistent. :)





#### PR Dependency Tree


* **PR #69** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)