### PR TITLE
refactor: Make IDs separate types

### DIFF
--- a/pkg/preparation/configurations/model/configuration.go
+++ b/pkg/preparation/configurations/model/configuration.go
@@ -67,7 +67,7 @@ func WithShardSize(shardSize uint64) ConfigurationOption {
 
 // validateConfiguration checks if the configuration is valid.
 func validateConfiguration(u *Configuration) (*Configuration, error) {
-	if u.id == uuid.Nil {
+	if u.id == types.ConfigurationID(uuid.Nil) {
 		return nil, types.ErrEmpty{Field: "id"}
 	}
 	if u.name == "" {
@@ -85,7 +85,7 @@ func validateConfiguration(u *Configuration) (*Configuration, error) {
 // NewConfiguration creates a new Configuration instance with the given name and options.
 func NewConfiguration(name string, opts ...ConfigurationOption) (*Configuration, error) {
 	u := &Configuration{
-		id:        uuid.New(),
+		id:        types.ConfigurationID(uuid.New()),
 		name:      name,
 		shardSize: DefaultShardSize, // default shard size
 		createdAt: time.Now().UTC().Truncate(time.Second),

--- a/pkg/preparation/dag/model/dagscan.go
+++ b/pkg/preparation/dag/model/dagscan.go
@@ -69,7 +69,7 @@ type dagScan struct {
 
 // validation conditions -- should not be callable externally, all scans outside this module MUST be valid
 func validateDAGScan(d *dagScan) (*dagScan, error) {
-	if d.fsEntryID == uuid.Nil {
+	if d.fsEntryID == types.FSEntryID(uuid.Nil) {
 		return nil, types.ErrEmpty{"fsEntryID"}
 	}
 	if !validDAGScanState(d.state) {

--- a/pkg/preparation/dag/model/node.go
+++ b/pkg/preparation/dag/model/node.go
@@ -198,7 +198,7 @@ func validateRawNode(node *RawNode) error {
 	if node.cid.Type() != cid.Raw {
 		return fmt.Errorf("invalid CID type: expected Raw, got %x", node.cid.Type())
 	}
-	if node.sourceID == uuid.Nil {
+	if node.sourceID == types.SourceID(uuid.Nil) {
 		return types.ErrEmpty{Field: "sourceID"}
 	}
 	return nil
@@ -228,7 +228,7 @@ type NodeWriter func(cid cid.Cid, size uint64, ufsdata []byte, path string, sour
 func WriteNodeToDatabase(writer NodeWriter, node Node) error {
 	switch n := node.(type) {
 	case *UnixFSNode:
-		return writer(n.cid, n.size, n.ufsdata, "", uuid.Nil, 0)
+		return writer(n.cid, n.size, n.ufsdata, "", types.SourceID(uuid.Nil), 0)
 	case *RawNode:
 		return writer(n.cid, n.size, nil, n.path, n.sourceID, n.offset)
 	default:

--- a/pkg/preparation/scans/model/fsentry.go
+++ b/pkg/preparation/scans/model/fsentry.go
@@ -72,7 +72,7 @@ type Directory struct {
 func (d *Directory) isFsEntry() {}
 
 func validateFsEntry(f *fsEntry) error {
-	if f.id == uuid.Nil {
+	if f.id == types.FSEntryID(uuid.Nil) {
 		return types.ErrEmpty{"id"}
 	}
 	if f.path == "" {
@@ -84,7 +84,7 @@ func validateFsEntry(f *fsEntry) error {
 	if f.checksum == nil {
 		return types.ErrEmpty{"checksum"}
 	}
-	if f.sourceID == uuid.Nil {
+	if f.sourceID == types.SourceID(uuid.Nil) {
 		return types.ErrEmpty{"sourceID"}
 	}
 	return nil
@@ -93,7 +93,7 @@ func validateFsEntry(f *fsEntry) error {
 func NewFile(path string, lastModified time.Time, mode fs.FileMode, size uint64, checksum []byte, sourceID types.SourceID) (*File, error) {
 	file := &File{
 		fsEntry: fsEntry{
-			id:           uuid.New(),
+			id:           types.FSEntryID(uuid.New()),
 			path:         path,
 			lastModified: lastModified,
 			mode:         mode,
@@ -111,7 +111,7 @@ func NewFile(path string, lastModified time.Time, mode fs.FileMode, size uint64,
 func NewDirectory(path string, lastModified time.Time, mode fs.FileMode, checksum []byte, sourceID types.SourceID) (*Directory, error) {
 	directory := &Directory{
 		fsEntry: fsEntry{
-			id:           uuid.New(),
+			id:           types.FSEntryID(uuid.New()),
 			path:         path,
 			lastModified: lastModified,
 			mode:         mode,

--- a/pkg/preparation/scans/model/scan.go
+++ b/pkg/preparation/scans/model/scan.go
@@ -46,10 +46,10 @@ type Scan struct {
 
 // validation conditions -- should not be callable externally, all scans outside this module MUST be valid
 func validateScan(s *Scan) (*Scan, error) {
-	if s.id == uuid.Nil {
+	if s.id == types.ScanID(uuid.Nil) {
 		return nil, types.ErrEmpty{"id"}
 	}
-	if s.uploadID == uuid.Nil {
+	if s.uploadID == types.UploadID(uuid.Nil) {
 		return nil, types.ErrEmpty{"update id"}
 	}
 	if !validScanState(s.state) {
@@ -98,7 +98,7 @@ func (s *Scan) HasRootID() bool {
 
 func (s *Scan) RootID() types.FSEntryID {
 	if s.rootID == nil {
-		return uuid.Nil // Return an empty FSEntryID if rootID is not set
+		return types.FSEntryID(uuid.Nil) // Return an empty FSEntryID if rootID is not set
 	}
 	return *s.rootID
 }
@@ -146,7 +146,7 @@ func (s *Scan) Start() error {
 
 func NewScan(uploadID types.UploadID) (*Scan, error) {
 	scan := &Scan{
-		id:        uuid.New(),
+		id:        types.ScanID(uuid.New()),
 		uploadID:  uploadID,
 		state:     ScanStatePending,
 		createdAt: time.Now().UTC().Truncate(time.Second),

--- a/pkg/preparation/scans/scans_test.go
+++ b/pkg/preparation/scans/scans_test.go
@@ -28,8 +28,8 @@ func (m repoErrOnUpdateScan) UpdateScan(ctx context.Context, scan *model.Scan) e
 var _ scans.Repo = (*repoErrOnUpdateScan)(nil)
 
 func newScanAndProcess(t *testing.T) (*model.Scan, scans.Scans) {
-	uploadID := uuid.New()
-	sourceID := uuid.New()
+	uploadID := types.UploadID(uuid.New())
+	sourceID := types.SourceID(uuid.New())
 	scan, err := model.NewScan(uploadID)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create new scan: %v", err))

--- a/pkg/preparation/scans/walker/walker_test.go
+++ b/pkg/preparation/scans/walker/walker_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/storacha/go-ucanto/core/iterable"
 	"github.com/storacha/guppy/pkg/preparation/scans/model"
 	"github.com/storacha/guppy/pkg/preparation/scans/walker"
+	"github.com/storacha/guppy/pkg/preparation/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,10 +76,10 @@ type mockFSVisitor struct {
 
 func (v *mockFSVisitor) VisitFile(path string, dirEntry fs.DirEntry) (*model.File, error) {
 	v.visitedFiles = append(v.visitedFiles, path)
-	return model.NewFile(path, time.Now(), 0, 0, []byte(path), uuid.New())
+	return model.NewFile(path, time.Now(), 0, 0, []byte(path), types.SourceID(uuid.New()))
 }
 func (v *mockFSVisitor) VisitDirectory(path string, dirEntry fs.DirEntry, children []model.FSEntry) (*model.Directory, error) {
 	v.visitedDirectories = append(v.visitedDirectories, path)
 	v.visitedChildren[path] = children
-	return model.NewDirectory(path, time.Now(), 0, []byte(path), uuid.New())
+	return model.NewDirectory(path, time.Now(), 0, []byte(path), types.SourceID(uuid.New()))
 }

--- a/pkg/preparation/sources/model/source.go
+++ b/pkg/preparation/sources/model/source.go
@@ -66,7 +66,7 @@ func (s *Source) ConnectionParams() ConnectionParams {
 }
 
 func validateSource(s *Source) (*Source, error) {
-	if s.id == uuid.Nil {
+	if s.id == types.SourceID(uuid.Nil) {
 		return nil, types.ErrEmpty{Field: "id"}
 	}
 	if s.name == "" {
@@ -83,7 +83,7 @@ type SourceOption func(*Source) error
 // Returns the created Source or an error if any option fails or validation does not pass.
 func NewSource(name string, path string, opts ...SourceOption) (*Source, error) {
 	src := &Source{
-		id:        uuid.New(),
+		id:        types.SourceID(uuid.New()),
 		name:      name,
 		createdAt: time.Now().UTC().Truncate(time.Second),
 		updatedAt: time.Now().UTC().Truncate(time.Second),

--- a/pkg/preparation/sqlrepo/configurations.go
+++ b/pkg/preparation/sqlrepo/configurations.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/storacha/guppy/pkg/preparation/configurations"
 	configurationsmodel "github.com/storacha/guppy/pkg/preparation/configurations/model"
 	"github.com/storacha/guppy/pkg/preparation/types"
@@ -74,12 +75,15 @@ func (r *repo) getConfigurationFromRow(row *sql.Row) (*configurationsmodel.Confi
 		createdAt *time.Time,
 		shardSize *uint64,
 	) error {
-		return row.Scan(
-			id,
+		if err := row.Scan(
+			(*uuid.UUID)(id),
 			name,
 			timestampScanner(createdAt),
 			shardSize,
-		)
+		); err != nil {
+			return fmt.Errorf("scanning configuration row: %w", err)
+		}
+		return nil
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil

--- a/pkg/preparation/sqlrepo/scans_test.go
+++ b/pkg/preparation/sqlrepo/scans_test.go
@@ -9,13 +9,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/storacha/guppy/pkg/preparation/sqlrepo"
 	"github.com/storacha/guppy/pkg/preparation/testutil"
+	"github.com/storacha/guppy/pkg/preparation/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCreateScan(t *testing.T) {
 	t.Run("with an upload ID", func(t *testing.T) {
 		repo := sqlrepo.New(testutil.CreateTestDB(t))
-		uploadID := uuid.New()
+		uploadID := types.UploadID(uuid.New())
 
 		scan, err := repo.CreateScan(t.Context(), uploadID)
 		require.NoError(t, err)
@@ -28,13 +29,13 @@ func TestCreateScan(t *testing.T) {
 
 	t.Run("with a nil upload ID", func(t *testing.T) {
 		repo := sqlrepo.New(testutil.CreateTestDB(t))
-		_, err := repo.CreateScan(t.Context(), uuid.Nil)
+		_, err := repo.CreateScan(t.Context(), types.UploadID(uuid.Nil))
 		require.ErrorContains(t, err, "update id cannot be empty")
 	})
 
 	t.Run("when the DB fails", func(t *testing.T) {
 		repo := sqlrepo.New(testutil.CreateTestDB(t))
-		uploadID := uuid.New()
+		uploadID := types.UploadID(uuid.New())
 
 		// Simulate a DB failure by canceling the context before the operation.
 		ctx, cancel := context.WithCancel(t.Context())
@@ -49,7 +50,7 @@ func TestFindOrCreateFile(t *testing.T) {
 	t.Run("finds a matching file entry, or creates a new one", func(t *testing.T) {
 		repo := sqlrepo.New(testutil.CreateTestDB(t))
 		modTime := time.Now().UTC().Truncate(time.Second)
-		sourceId := uuid.New()
+		sourceId := types.SourceID(uuid.New())
 
 		file, created, err := repo.FindOrCreateFile(t.Context(), "some/file.txt", modTime, 0644, 12345, []byte("checksum"), sourceId)
 		require.NoError(t, err)
@@ -70,7 +71,7 @@ func TestFindOrCreateFile(t *testing.T) {
 	t.Run("refuses to create a file entry for a directory", func(t *testing.T) {
 		repo := sqlrepo.New(testutil.CreateTestDB(t))
 		modTime := time.Now().UTC().Truncate(time.Second)
-		sourceId := uuid.New()
+		sourceId := types.SourceID(uuid.New())
 		_, _, err := repo.FindOrCreateFile(t.Context(), "some/directory", modTime, fs.ModeDir|0644, 12345, []byte("checksum"), sourceId)
 		require.ErrorContains(t, err, "cannot create a file with directory mode")
 	})
@@ -80,7 +81,7 @@ func TestFindOrCreateDirectory(t *testing.T) {
 	t.Run("finds a matching directory entry, or creates a new one", func(t *testing.T) {
 		repo := sqlrepo.New(testutil.CreateTestDB(t))
 		modTime := time.Now().UTC().Truncate(time.Second)
-		sourceId := uuid.New()
+		sourceId := types.SourceID(uuid.New())
 
 		file, created, err := repo.FindOrCreateDirectory(t.Context(), "some/directory", modTime, fs.ModeDir|0644, []byte("checksum"), sourceId)
 		require.NoError(t, err)
@@ -101,7 +102,7 @@ func TestFindOrCreateDirectory(t *testing.T) {
 	t.Run("refuses to create a directory entry for a file", func(t *testing.T) {
 		repo := sqlrepo.New(testutil.CreateTestDB(t))
 		modTime := time.Now().UTC().Truncate(time.Second)
-		sourceId := uuid.New()
+		sourceId := types.SourceID(uuid.New())
 		_, _, err := repo.FindOrCreateDirectory(t.Context(), "some/file.txt", modTime, 0644, []byte("different-checksum"), sourceId)
 		require.ErrorContains(t, err, "cannot create a directory with file mode")
 	})

--- a/pkg/preparation/types/id.go
+++ b/pkg/preparation/types/id.go
@@ -2,17 +2,17 @@ package types
 
 import "github.com/google/uuid"
 
-// SourceID is an alias for uuid.UUID and uniquely identifies a source.
-type SourceID = uuid.UUID
+// SourceID uniquely identifies a source.
+type SourceID uuid.UUID
 
-// ConfigurationID is an alias for uuid.UUID and uniquely identifies a configuration.
-type ConfigurationID = uuid.UUID
+// ConfigurationID uniquely identifies a configuration.
+type ConfigurationID uuid.UUID
 
-// UploadID is an alias for uuid.UUID and uniquely identifies an upload.
-type UploadID = uuid.UUID
+// UploadID uniquely identifies an upload.
+type UploadID uuid.UUID
 
-// ScanID is an alias for uuid.UUID and uniquely identifies a scan.
-type ScanID = uuid.UUID
+// ScanID uniquely identifies a scan.
+type ScanID uuid.UUID
 
-// FSEntryID is an alias for uuid.UUID and uniquely identifies a filesystem entry.
-type FSEntryID = uuid.UUID
+// FSEntryID uniquely identifies a filesystem entry.
+type FSEntryID uuid.UUID

--- a/pkg/preparation/uploads/model/upload.go
+++ b/pkg/preparation/uploads/model/upload.go
@@ -100,7 +100,7 @@ func (u *Upload) HasRootFSEntryID() bool {
 
 func (u *Upload) RootFSEntryID() types.FSEntryID {
 	if u.rootFSEntryID == nil {
-		return uuid.Nil // Return an empty FSEntryID if rootFSEntryID is not set
+		return types.FSEntryID(uuid.Nil) // Return an empty FSEntryID if rootFSEntryID is not set
 	}
 	return *u.rootFSEntryID
 }
@@ -191,13 +191,13 @@ func (u *Upload) Restart() error {
 
 func validateUpload(upload *Upload) error {
 
-	if upload.id == uuid.Nil {
+	if upload.id == types.UploadID(uuid.Nil) {
 		return types.ErrEmpty{"upload ID"}
 	}
-	if upload.configurationID == uuid.Nil {
+	if upload.configurationID == types.ConfigurationID(uuid.Nil) {
 		return types.ErrEmpty{"configuration ID"}
 	}
-	if upload.sourceID == uuid.Nil {
+	if upload.sourceID == types.SourceID(uuid.Nil) {
 		return types.ErrEmpty{"source ID"}
 	}
 	if upload.createdAt.IsZero() {
@@ -224,7 +224,7 @@ func validateUpload(upload *Upload) error {
 // NewUpload creates a new Upload instance with the given parameters.
 func NewUpload(configurationID types.ConfigurationID, sourceID types.SourceID) (*Upload, error) {
 	upload := &Upload{
-		id:              uuid.New(),
+		id:              types.UploadID(uuid.New()),
 		configurationID: configurationID,
 		sourceID:        sourceID,
 		createdAt:       time.Now(),
@@ -246,7 +246,8 @@ func WriteUploadToDatabase(writer UploadWriter, upload *Upload) error {
 	return writer(upload.id, upload.configurationID, upload.sourceID, upload.createdAt, upload.updatedAt, upload.state, upload.errorMessage, upload.rootFSEntryID, upload.rootCID)
 }
 
-// UploadScanner is a function type that defines the signature for scanning uploads from a database row
+// UploadScanner is a function type that defines the signature for scanning
+// uploads from a database row
 type UploadScanner func(id *types.UploadID, configurationID *types.ConfigurationID, sourceID *types.SourceID, createdAt *time.Time, updatedAt *time.Time, state *UploadState, errorMessage **string, rootFSEntryID **types.FSEntryID, rootCID **cid.Cid) error
 
 // ReadUploadFromDatabase reads an upload from the database using the provided scanner function.

--- a/pkg/preparation/uploads/uploads.go
+++ b/pkg/preparation/uploads/uploads.go
@@ -86,7 +86,7 @@ func (u Uploads) ExecuteUpload(ctx context.Context, upload *model.Upload, opts .
 				return fmt.Errorf("running new scan: %w", err)
 			}
 			// check if scan completed successfully
-			if fsEntryID != uuid.Nil {
+			if fsEntryID != types.FSEntryID(uuid.Nil) {
 				close(e.dagWork) // close the work channel to signal completion
 				if err := upload.ScanComplete(fsEntryID); err != nil {
 					return fmt.Errorf("completing scan: %w", err)


### PR DESCRIPTION
…and reveal that Chekhov's footgun has, in fact, already gone off.

Is this worth the hassle? It causes a lot of changes, but I'm pretty sure it's only a big deal because I'm changing it across a lot of code all at once. And should I be doing it differently at all?

---

Working through this further, it looks like `uuid.UUID` was supporting us by implementing `sql.Scanner`, and there's no good way to get that `Scan()` behavior on the derived types other than writing out a method for each one that converts to `uuid.UUID` and calls its `Scan()`. That seems pretty heavy-handed. I'll abandon this for now and just rely on tests to catch when we get IDs in the wrong order.



#### PR Dependency Tree


* **PR #72**
  * **PR #73**
    * **PR #74** 👈
      * **PR #66**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)