### PR TITLE
chore: upgrade ucanto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/multiformats/go-varint v0.0.7
 	github.com/spf13/afero v1.6.0
 	github.com/storacha/go-libstoracha v0.2.0
-	github.com/storacha/go-ucanto v0.4.2
+	github.com/storacha/go-ucanto v0.5.0
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.25.7
 	golang.org/x/sync v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -504,6 +504,8 @@ github.com/storacha/go-libstoracha v0.2.0 h1:x3yz7PrTqVWT86hu/3OcKrS/72mLKfSdfIn
 github.com/storacha/go-libstoracha v0.2.0/go.mod h1:68KXcak6CtWPKHlPV7emXbRbC+6LBiIWPbYrJ0urVf8=
 github.com/storacha/go-ucanto v0.4.2 h1:d9m9+a5W7U8VwIMqtGIwJOP3KZtEJOKNkQhveDczHEI=
 github.com/storacha/go-ucanto v0.4.2/go.mod h1:/I6qtE+oDHc+6lBc/glN+RFx0cbP/mDj4gihD7YezWc=
+github.com/storacha/go-ucanto v0.5.0 h1:BCYfTOjJ7DxmoGwpZn4N1XITWj1BdKIbk5Ok7kMoQ6I=
+github.com/storacha/go-ucanto v0.5.0/go.mod h1:/I6qtE+oDHc+6lBc/glN+RFx0cbP/mDj4gihD7YezWc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pkg/client/claimaccess_test.go
+++ b/pkg/client/claimaccess_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/receipt/fx"
+	"github.com/storacha/go-ucanto/core/result"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/server"
 	uhelpers "github.com/storacha/go-ucanto/testing/helpers"
 	"github.com/storacha/go-ucanto/ucan"
@@ -50,10 +52,10 @@ func TestClaimAccess(t *testing.T) {
 						cap ucan.Capability[access.ClaimCaveats],
 						inv invocation.Invocation,
 						context server.InvocationContext,
-					) (access.ClaimOk, fx.Effects, error) {
+					) (result.Result[access.ClaimOk, failure.IPLDBuilderFailure], fx.Effects, error) {
 						assert.Equal(t, c.Issuer().DID().String(), cap.With(), "expected to claim access for the agent")
 
-						return access.ClaimOk{Delegations: storedDels}, nil, nil
+						return result.Ok[access.ClaimOk, failure.IPLDBuilderFailure](access.ClaimOk{Delegations: storedDels}), nil, nil
 					},
 				),
 			),
@@ -88,8 +90,8 @@ func TestClaimAccess(t *testing.T) {
 						cap ucan.Capability[access.ClaimCaveats],
 						inv invocation.Invocation,
 						context server.InvocationContext,
-					) (access.ClaimOk, fx.Effects, error) {
-						return access.ClaimOk{}, nil, fmt.Errorf("Something went wrong!")
+					) (result.Result[access.ClaimOk, failure.IPLDBuilderFailure], fx.Effects, error) {
+						return nil, nil, fmt.Errorf("Something went wrong!")
 					},
 				),
 			),

--- a/pkg/client/requestaccess_test.go
+++ b/pkg/client/requestaccess_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/storacha/go-libstoracha/capabilities/access"
 	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/receipt/fx"
+	"github.com/storacha/go-ucanto/core/result"
+	"github.com/storacha/go-ucanto/core/result/failure"
 	"github.com/storacha/go-ucanto/server"
 	uhelpers "github.com/storacha/go-ucanto/testing/helpers"
 	"github.com/storacha/go-ucanto/ucan"
@@ -29,13 +31,15 @@ func TestRequestAccess(t *testing.T) {
 						cap ucan.Capability[access.AuthorizeCaveats],
 						inv invocation.Invocation,
 						context server.InvocationContext,
-					) (access.AuthorizeOk, fx.Effects, error) {
+					) (result.Result[access.AuthorizeOk, failure.IPLDBuilderFailure], fx.Effects, error) {
 						invokedInvocations = append(invokedInvocations, inv)
 						invokedCapabilities = append(invokedCapabilities, cap)
-						return access.AuthorizeOk{
-							Request:    inv.Link(),
-							Expiration: 123,
-						}, nil, nil
+						return result.Ok[access.AuthorizeOk, failure.IPLDBuilderFailure](
+							access.AuthorizeOk{
+								Request:    inv.Link(),
+								Expiration: 123,
+							},
+						), nil, nil
 					},
 				),
 			),

--- a/pkg/client/spaceblobadd_test.go
+++ b/pkg/client/spaceblobadd_test.go
@@ -184,7 +184,7 @@ func setupTestUCANServer(t *testing.T, serverPrincipal principal.Signer, putBlob
 	spaceBlobAddMethod := server.Provide(
 		spaceblobcap.Add,
 		func(ctx context.Context,
-			cap ucan.Capability[spaceblobcap.AddCaveats], inv invocation.Invocation, context server.InvocationContext) (spaceblobcap.AddOk, fx.Effects, error) {
+			cap ucan.Capability[spaceblobcap.AddCaveats], inv invocation.Invocation, context server.InvocationContext) (result.Result[spaceblobcap.AddOk, failure.IPLDBuilderFailure], fx.Effects, error) {
 			// add task for blob/allocate
 			blobDigest := cap.Nb().Blob.Digest
 			blobSize := cap.Nb().Blob.Size
@@ -311,23 +311,23 @@ func setupTestUCANServer(t *testing.T, serverPrincipal principal.Signer, putBlob
 				},
 			}
 
-			return ok, fxs, nil
+			return result.Ok[spaceblobcap.AddOk, failure.IPLDBuilderFailure](ok), fxs, nil
 		},
 	)
 
 	// ucan/conclude handler
 	ucanConcludeMethod := server.Provide(
 		ucancap.Conclude,
-		func(ctx context.Context, capability ucan.Capability[ucancap.ConcludeCaveats], invocation invocation.Invocation, context server.InvocationContext) (ucancap.ConcludeOk, fx.Effects, error) {
-			return ucancap.ConcludeOk{}, nil, nil
+		func(ctx context.Context, capability ucan.Capability[ucancap.ConcludeCaveats], invocation invocation.Invocation, context server.InvocationContext) (result.Result[ucancap.ConcludeOk, failure.IPLDBuilderFailure], fx.Effects, error) {
+			return result.Ok[ucancap.ConcludeOk, failure.IPLDBuilderFailure](ucancap.ConcludeOk{}), nil, nil
 		},
 	)
 
 	// upload/add handler
 	uploadAddMethod := server.Provide(
 		uploadcap.Add,
-		func(ctx context.Context, capability ucan.Capability[uploadcap.AddCaveats], invocation invocation.Invocation, context server.InvocationContext) (uploadcap.AddOk, fx.Effects, error) {
-			return uploadcap.AddOk{}, nil, nil
+		func(ctx context.Context, capability ucan.Capability[uploadcap.AddCaveats], invocation invocation.Invocation, context server.InvocationContext) (result.Result[uploadcap.AddOk, failure.IPLDBuilderFailure], fx.Effects, error) {
+			return result.Ok[uploadcap.AddOk, failure.IPLDBuilderFailure](uploadcap.AddOk{}), nil, nil
 		},
 	)
 


### PR DESCRIPTION
The signature for handlers changed in go-ucanto. This PR updates guppy to use the new code.

Depends on https://github.com/storacha/go-ucanto/pull/55 ✅ 