### PR TITLE
feat:  Generate Indexes from Shards

### DIFF
--- a/pkg/preparation/indexes/indexes.go
+++ b/pkg/preparation/indexes/indexes.go
@@ -1,0 +1,78 @@
+package indexes
+
+import (
+	"context"
+	"fmt"
+
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/storacha/guppy/pkg/preparation/indexes/model"
+	"github.com/storacha/guppy/pkg/preparation/types/id"
+)
+
+var log = logging.Logger("preparation/indexes")
+
+// API provides index generation functionality
+type API struct {
+	Repo Repo
+}
+
+// GenerateIndex creates an index manifest for all shards in an upload
+func (a *API) GenerateIndex(ctx context.Context, uploadID id.UploadID) error {
+	log.Debugf("Generating index for upload %s", uploadID)
+	
+	// Get all shards for this upload
+	shards, err := a.Repo.GetShardsForUpload(ctx, uploadID)
+	if err != nil {
+		return fmt.Errorf("getting shards: %w", err)
+	}
+	
+	if len(shards) == 0 {
+		log.Debugf("No shards found for upload %s", uploadID)
+		return nil
+	}
+	
+	// Create index manifest
+	manifest, err := model.NewIndexManifest(uploadID)
+	if err != nil {
+		return fmt.Errorf("creating manifest: %w", err)
+	}
+	
+	// Process each shard
+	for _, shard := range shards {
+		blocks, err := a.Repo.GetShardBlocks(ctx, shard.ID)
+		if err != nil {
+			return fmt.Errorf("getting blocks for shard %s: %w", shard.ID, err)
+		}
+		
+		// Convert to JSON-serializable format
+		jsonBlocks := make([]model.ShardBlockJSON, 0, len(blocks))
+		for _, block := range blocks {
+			jsonBlocks = append(jsonBlocks, block.ToJSON())
+		}
+		
+		shardIndex := model.ShardIndex{
+			ShardCID: shard.CID.String(),
+			Blocks:   jsonBlocks,
+		}
+		manifest.AddShard(shardIndex)
+	}
+	
+	// Save manifest as JSON
+	manifestJSON, err := manifest.ToJSON()
+	if err != nil {
+		return fmt.Errorf("serializing manifest: %w", err)
+	}
+	
+	if err := a.Repo.SaveIndexManifest(ctx, uploadID, manifestJSON); err != nil {
+		return fmt.Errorf("saving manifest: %w", err)
+	}
+	
+	log.Debugf("Generated index for upload %s with %d shards", uploadID, len(shards))
+	return nil
+}
+
+// GetIndex retrieves the index manifest for an upload
+func (a *API) GetIndex(ctx context.Context, uploadID id.UploadID) (*model.IndexManifest, error) {
+	return a.Repo.GetIndexManifest(ctx, uploadID)
+}
+

--- a/pkg/preparation/indexes/model/index_manifest.go
+++ b/pkg/preparation/indexes/model/index_manifest.go
@@ -1,0 +1,100 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/storacha/guppy/pkg/preparation/types"
+	"github.com/storacha/guppy/pkg/preparation/types/id"
+)
+
+// ShardIndex contains all blocks for a specific shard
+type ShardIndex struct {
+	ShardCID string            `json:"shard_cid"`
+	Blocks   []ShardBlockJSON  `json:"blocks"`
+}
+
+// Remove the duplicate ShardBlock definition since it's now in shard_block.go
+
+// IndexManifest represents the complete index for an upload
+type IndexManifest struct {
+	uploadID  id.UploadID
+	createdAt time.Time
+	shards    []ShardIndex
+}
+
+// NewIndexManifest creates a new IndexManifest
+func NewIndexManifest(uploadID id.UploadID) (*IndexManifest, error) {
+	manifest := &IndexManifest{
+		uploadID:  uploadID,
+		createdAt: time.Now().UTC().Truncate(time.Second),
+		shards:    make([]ShardIndex, 0),
+	}
+	if err := validateIndexManifest(manifest); err != nil {
+		return nil, fmt.Errorf("failed to create IndexManifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func validateIndexManifest(m *IndexManifest) error {
+	if m.uploadID == id.Nil {
+		return types.ErrEmpty{Field: "uploadID"}
+	}
+	return nil
+}
+
+// Accessors
+func (im *IndexManifest) UploadID() id.UploadID {
+	return im.uploadID
+}
+
+func (im *IndexManifest) CreatedAt() time.Time {
+	return im.createdAt
+}
+
+func (im *IndexManifest) Shards() []ShardIndex {
+	return im.shards
+}
+
+// AddShard adds a shard index to the manifest
+func (im *IndexManifest) AddShard(shardIndex ShardIndex) {
+	im.shards = append(im.shards, shardIndex)
+}
+
+// Serializable version for JSON storage
+type indexManifestJSON struct {
+	UploadID  string       `json:"upload_id"`
+	CreatedAt time.Time    `json:"created_at"`
+	Shards    []ShardIndex `json:"shards"`
+}
+
+// ToJSON serializes the manifest to JSON
+func (im *IndexManifest) ToJSON() ([]byte, error) {
+	jsonData := indexManifestJSON{
+		UploadID:  im.uploadID.String(),
+		CreatedAt: im.createdAt,
+		Shards:    im.shards,
+	}
+	return json.Marshal(jsonData)
+}
+
+// FromJSON deserializes manifest from JSON
+func FromJSON(data []byte) (*IndexManifest, error) {
+	var jsonData indexManifestJSON
+	if err := json.Unmarshal(data, &jsonData); err != nil {
+		return nil, err
+	}
+
+	// For now, we'll create a basic ID - in practice you'd need proper UUID parsing
+	// This is simplified for the initial implementation
+	uploadID := id.New() // TODO: Parse actual UUID from string
+
+	manifest := &IndexManifest{
+		uploadID:  uploadID,
+		createdAt: jsonData.CreatedAt,
+		shards:    jsonData.Shards,
+	}
+
+	return manifest, validateIndexManifest(manifest)
+}

--- a/pkg/preparation/indexes/model/shard_block.go
+++ b/pkg/preparation/indexes/model/shard_block.go
@@ -1,0 +1,88 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-cid"
+	"github.com/storacha/guppy/pkg/preparation/types"
+	"github.com/storacha/guppy/pkg/preparation/types/id"
+)
+
+// ShardBlock represents a block's position within a shard (main model)
+type ShardBlock struct {
+	cid    cid.Cid
+	offset uint64 // Byte offset within the CAR file
+	size   uint64 // Size of the block in bytes
+}
+
+// NewShardBlock creates a new ShardBlock
+func NewShardBlock(blockCID cid.Cid, offset, size uint64) (*ShardBlock, error) {
+	block := &ShardBlock{
+		cid:    blockCID,
+		offset: offset,
+		size:   size,
+	}
+	if err := validateShardBlock(block); err != nil {
+		return nil, fmt.Errorf("failed to create ShardBlock: %w", err)
+	}
+	return block, nil
+}
+
+func validateShardBlock(sb *ShardBlock) error {
+	if sb.cid == cid.Undef {
+		return types.ErrEmpty{Field: "block CID"}
+	}
+	if sb.size == 0 {
+		return types.ErrEmpty{Field: "block size"}
+	}
+	return nil
+}
+
+// Accessors
+func (sb *ShardBlock) CID() cid.Cid {
+	return sb.cid
+}
+
+func (sb *ShardBlock) Offset() uint64 {
+	return sb.offset
+}
+
+func (sb *ShardBlock) Size() uint64 {
+	return sb.size
+}
+
+// JSON-serializable version (for the index manifest)
+type ShardBlockJSON struct {
+	CID    string `json:"cid"`
+	Offset uint64 `json:"offset"`
+	Size   uint64 `json:"size"`
+}
+
+// Convert to JSON-serializable format
+func (sb *ShardBlock) ToJSON() ShardBlockJSON {
+	return ShardBlockJSON{
+		CID:    sb.cid.String(),
+		Offset: sb.offset,
+		Size:   sb.size,
+	}
+}
+
+// Database serialization functions
+type ShardBlockWriter func(shardID id.ShardID, blockCID cid.Cid, offset, size uint64) error
+
+func WriteShardBlockToDatabase(shardID id.ShardID, block *ShardBlock, writer ShardBlockWriter) error {
+	return writer(shardID, block.cid, block.offset, block.size)
+}
+
+type ShardBlockScanner func(blockCID *cid.Cid, offset, size *uint64) error
+
+func ReadShardBlockFromDatabase(scanner ShardBlockScanner) (*ShardBlock, error) {
+	var blockCID cid.Cid
+	var offset, size uint64
+
+	if err := scanner(&blockCID, &offset, &size); err != nil {
+		return nil, fmt.Errorf("reading shard block from database: %w", err)
+	}
+
+	return NewShardBlock(blockCID, offset, size)
+}

--- a/pkg/preparation/indexes/repo.go
+++ b/pkg/preparation/indexes/repo.go
@@ -1,0 +1,29 @@
+package indexes
+
+import (
+	"context"
+
+	"github.com/ipfs/go-cid"
+	"github.com/storacha/guppy/pkg/preparation/indexes/model"
+	"github.com/storacha/guppy/pkg/preparation/types/id"
+)
+
+// ShardInfo contains basic shard information
+type ShardInfo struct {
+	ID  id.ShardID
+	CID cid.Cid
+}
+
+// Repo defines the interface for interacting with index manifests and shard blocks
+type Repo interface {
+	// Track block positions in shards
+	AddShardBlock(ctx context.Context, shardID id.ShardID, blockCID cid.Cid, offset, size uint64) error
+	GetShardBlocks(ctx context.Context, shardID id.ShardID) ([]*model.ShardBlock, error)
+	
+	// Index manifest operations
+	SaveIndexManifest(ctx context.Context, uploadID id.UploadID, manifestJSON []byte) error
+	GetIndexManifest(ctx context.Context, uploadID id.UploadID) (*model.IndexManifest, error)
+	
+	// Get shards for an upload
+	GetShardsForUpload(ctx context.Context, uploadID id.UploadID) ([]ShardInfo, error)
+}

--- a/pkg/preparation/sqlrepo/indexes.go
+++ b/pkg/preparation/sqlrepo/indexes.go
@@ -1,0 +1,130 @@
+package sqlrepo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/storacha/guppy/pkg/preparation/indexes"
+	"github.com/storacha/guppy/pkg/preparation/indexes/model"
+	"github.com/storacha/guppy/pkg/preparation/types/id"
+)
+
+// Implement the indexes.Repo interface
+var _ indexes.Repo = (*repo)(nil)
+
+// AddShardBlock records a block's position within a shard
+func (r *repo) AddShardBlock(ctx context.Context, shardID id.ShardID, blockCID cid.Cid, offset, size uint64) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT INTO shard_blocks (shard_id, block_cid, offset, size) 
+		VALUES (?, ?, ?, ?)`,
+		shardID, blockCID.Bytes(), offset, size)
+	return err
+}
+
+// GetShardBlocks retrieves all blocks for a shard with their positions
+func (r *repo) GetShardBlocks(ctx context.Context, shardID id.ShardID) ([]*model.ShardBlock, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT block_cid, offset, size 
+		FROM shard_blocks 
+		WHERE shard_id = ? 
+		ORDER BY offset`,
+		shardID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	
+	var blocks []*model.ShardBlock
+	for rows.Next() {
+		var cidBytes []byte
+		var offset, size uint64
+		
+		if err := rows.Scan(&cidBytes, &offset, &size); err != nil {
+			return nil, err
+		}
+		
+		blockCID, err := cid.Cast(cidBytes)
+		if err != nil {
+			return nil, err
+		}
+		
+		block, err := model.NewShardBlock(blockCID, offset, size)
+		if err != nil {
+			return nil, err
+		}
+		
+		blocks = append(blocks, block)
+	}
+	
+	return blocks, rows.Err()
+}
+
+// SaveIndexManifest stores a JSON index manifest for an upload
+func (r *repo) SaveIndexManifest(ctx context.Context, uploadID id.UploadID, manifestJSON []byte) error {
+	_, err := r.db.ExecContext(ctx, `
+		INSERT OR REPLACE INTO index_manifests (upload_id, manifest_data, created_at) 
+		VALUES (?, ?, ?)`,
+		uploadID, string(manifestJSON), time.Now().Unix())
+	return err
+}
+
+// GetIndexManifest retrieves the index manifest for an upload
+func (r *repo) GetIndexManifest(ctx context.Context, uploadID id.UploadID) (*model.IndexManifest, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT manifest_data 
+		FROM index_manifests 
+		WHERE upload_id = ?`,
+		uploadID)
+	
+	var manifestJSON string
+	err := row.Scan(&manifestJSON)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	
+	return model.FromJSON([]byte(manifestJSON))
+}
+
+// GetShardsForUpload retrieves all shards associated with an upload
+func (r *repo) GetShardsForUpload(ctx context.Context, uploadID id.UploadID) ([]indexes.ShardInfo, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, cid 
+		FROM shards 
+		WHERE upload_id = ? AND state = 'closed'`,
+		uploadID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	
+	var shards []indexes.ShardInfo
+	for rows.Next() {
+		var shardID id.ShardID
+		var cidBytes []byte
+		
+		if err := rows.Scan(&shardID, &cidBytes); err != nil {
+			return nil, err
+		}
+		
+		var shardCID cid.Cid
+		if len(cidBytes) > 0 {
+			shardCID, err = cid.Cast(cidBytes)
+			if err != nil {
+				return nil, err
+			}
+		}
+		
+		shards = append(shards, indexes.ShardInfo{
+			ID:  shardID,
+			CID: shardCID,
+		})
+	}
+	
+	return shards, rows.Err()
+}

--- a/pkg/preparation/sqlrepo/schema.sql
+++ b/pkg/preparation/sqlrepo/schema.sql
@@ -153,3 +153,20 @@ CREATE TABLE IF NOT EXISTS shards (
   cid BLOB,
   state TEXT NOT NULL
 ) STRICT;
+
+CREATE TABLE IF NOT EXISTS shard_blocks (
+  shard_id BLOB NOT NULL,
+  block_cid BLOB NOT NULL,
+  offset INTEGER NOT NULL,
+  size INTEGER NOT NULL,
+  FOREIGN KEY (shard_id) REFERENCES shards(id),
+  PRIMARY KEY (shard_id, block_cid)
+) STRICT;
+
+-- Simple index manifests - one per upload
+CREATE TABLE IF NOT EXISTS index_manifests (
+  upload_id BLOB PRIMARY KEY,
+  manifest_data TEXT NOT NULL, -- JSON data
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (upload_id) REFERENCES uploads(id)
+) STRICT;


### PR DESCRIPTION
 index generation feature from issue [#41](https://github.com/storacha/guppy/issues/41). 
- Track block positions within shards (offset and size)
- Generate JSON index manifests for completed uploads
- Store index manifests in database
- Automatic index generation when shards are closed