### PR TITLE
feat: After an error, can be retried safely

### DIFF
--- a/pkg/preparation/dags/dags.go
+++ b/pkg/preparation/dags/dags.go
@@ -81,7 +81,7 @@ func (a API) RunDagScansForUpload(ctx context.Context, uploadID id.UploadID, nod
 				executions++
 			case model.DAGScanStateAwaitingChildren:
 				log.Debugf("Handling awaiting children for dag scan %s in state %s", dagScan.FsEntryID(), dagScan.State())
-				if err := a.HandleAwaitingChildren(ctx, dagScan); err != nil {
+				if err := a.handleAwaitingChildren(ctx, dagScan); err != nil {
 					return fmt.Errorf("handling awaiting children for dag scan %s: %w", dagScan.FsEntryID(), err)
 				}
 				// if the scan is now in a state where it can be executed, execute it
@@ -183,8 +183,8 @@ func (a API) executeDirectoryDAGScan(ctx context.Context, dagScan *model.Directo
 	return l.(cidlink.Link).Cid, err
 }
 
-// HandleAwaitingChildren checks if all child scans of a directory scan are completed and marks the parent scan pending if so.
-func (a API) HandleAwaitingChildren(ctx context.Context, dagScan model.DAGScan) error {
+// handleAwaitingChildren checks if all child scans of a directory scan are completed and marks the parent scan pending if so.
+func (a API) handleAwaitingChildren(ctx context.Context, dagScan model.DAGScan) error {
 	if dagScan.State() != model.DAGScanStateAwaitingChildren {
 		return fmt.Errorf("DAG scan is not in awaiting children state: %s", dagScan.State())
 	}

--- a/pkg/preparation/scans/repo.go
+++ b/pkg/preparation/scans/repo.go
@@ -14,6 +14,7 @@ type Repo interface {
 	CreateScan(ctx context.Context, uploadID id.UploadID) (*model.Scan, error)
 	FindOrCreateFile(ctx context.Context, path string, lastModified time.Time, mode fs.FileMode, size uint64, checksum []byte, sourceID id.SourceID, spaceDID did.DID) (*model.File, bool, error)
 	FindOrCreateDirectory(ctx context.Context, path string, lastModified time.Time, mode fs.FileMode, checksum []byte, sourceID id.SourceID, spaceDID did.DID) (*model.Directory, bool, error)
+	ScansForUploadByStatus(ctx context.Context, uploadID id.UploadID, states ...model.ScanState) ([]*model.Scan, error)
 	CreateDirectoryChildren(ctx context.Context, parent *model.Directory, children []model.FSEntry) error
 	DirectoryChildren(ctx context.Context, dir *model.Directory) ([]model.FSEntry, error)
 	UpdateScan(ctx context.Context, scan *model.Scan) error

--- a/pkg/preparation/scans/scans.go
+++ b/pkg/preparation/scans/scans.go
@@ -79,8 +79,8 @@ func (a API) executeScan(ctx context.Context, scan *model.Scan, fsEntryCb func(m
 	return fsEntry, nil
 }
 
-// OpenFile opens a file for reading, ensuring the checksum matches the expected value.
-func (a API) OpenFile(ctx context.Context, file *model.File) (fs.File, error) {
+// openFile opens a file for reading, ensuring the checksum matches the expected value.
+func (a API) openFile(ctx context.Context, file *model.File) (fs.File, error) {
 	fsys, err := a.SourceAccessor(ctx, file.SourceID())
 	if err != nil {
 		return nil, fmt.Errorf("accessing source for file %s: %w", file.ID(), err)
@@ -101,8 +101,8 @@ func (a API) OpenFile(ctx context.Context, file *model.File) (fs.File, error) {
 	return fsFile, nil
 }
 
-// GetFileByID retrieves a file by its ID from the repository, returning an error if not found.
-func (a API) GetFileByID(ctx context.Context, fileID id.FSEntryID) (*model.File, error) {
+// getFileByID retrieves a file by its ID from the repository, returning an error if not found.
+func (a API) getFileByID(ctx context.Context, fileID id.FSEntryID) (*model.File, error) {
 	file, err := a.Repo.GetFileByID(ctx, fileID)
 	if err != nil {
 		return nil, fmt.Errorf("getting file by ID %s: %w", fileID, err)
@@ -115,11 +115,11 @@ func (a API) GetFileByID(ctx context.Context, fileID id.FSEntryID) (*model.File,
 
 // OpenFileByID retrieves a file by its ID and opens it for reading, returning an error if not found or if the file cannot be opened.
 func (a API) OpenFileByID(ctx context.Context, fileID id.FSEntryID) (fs.File, id.SourceID, string, error) {
-	file, err := a.GetFileByID(ctx, fileID)
+	file, err := a.getFileByID(ctx, fileID)
 	if err != nil {
 		return nil, id.SourceID{}, "", err
 	}
-	fsFile, err := a.OpenFile(ctx, file)
+	fsFile, err := a.openFile(ctx, file)
 	if err != nil {
 		return nil, id.SourceID{}, "", err
 	}

--- a/pkg/preparation/sqlrepo/dags.go
+++ b/pkg/preparation/sqlrepo/dags.go
@@ -103,7 +103,8 @@ func (r *repo) dagScanScanner(sqlScanner sqlScanner) model.DAGScanScanner {
 	}
 }
 
-// DAGScansForUploadByStatus retrieves all DAG scans for a given upload ID and optional states.
+// DAGScansForUploadByStatus retrieves all DAG scans for a given upload ID
+// matching the given states, if given, or all if no states are provided.
 func (r *repo) DAGScansForUploadByStatus(ctx context.Context, uploadID id.UploadID, states ...model.DAGScanState) ([]model.DAGScan, error) {
 	query := `SELECT fs_entry_id, upload_id, space_did, created_at, updated_at, state, error_message, cid, kind FROM dag_scans WHERE upload_id = $1`
 	if len(states) > 0 {

--- a/pkg/preparation/sqlrepo/schema.sql
+++ b/pkg/preparation/sqlrepo/schema.sql
@@ -44,18 +44,7 @@ CREATE TABLE IF NOT EXISTS uploads (
   source_id BLOB NOT NULL,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
-  state TEXT NOT NULL CHECK (
-    state IN (
-      'pending',
-      'started',
-      'scanned',
-      'dagged',
-      'sharded',
-      'completed',
-      'failed',
-      'canceled'
-    )
-  ),
+  state TEXT NOT NULL CHECK (state IN ('pending', 'started')),
   error_message TEXT,
   root_fs_entry_id BLOB,
   root_cid BLOB,

--- a/pkg/preparation/uploads/model/upload.go
+++ b/pkg/preparation/uploads/model/upload.go
@@ -33,29 +33,15 @@ const (
 	// UploadStateCompleted indicates that the entire upload has completed
 	// successfully.
 	UploadStateCompleted UploadState = "completed"
-
-	// UploadStateFailed indicates that the upload has failed.
-	UploadStateFailed UploadState = "failed"
-
-	// UploadStateCanceled indicates that the upload has been canceled.
-	UploadStateCanceled UploadState = "canceled"
 )
 
 func validUploadState(state UploadState) bool {
 	switch state {
-	case UploadStatePending, UploadStateStarted, UploadStateScanned, UploadStateDagged, UploadStateCompleted, UploadStateFailed, UploadStateCanceled:
+	case UploadStatePending, UploadStateStarted, UploadStateScanned, UploadStateDagged, UploadStateCompleted:
 		return true
 	default:
 		return false
 	}
-}
-
-func TerminatedState(state UploadState) bool {
-	return state == UploadStateCompleted || state == UploadStateFailed || state == UploadStateCanceled
-}
-
-func RestartableState(state UploadState) bool {
-	return state == UploadStateStarted || state == UploadStateScanned || state == UploadStateDagged || state == UploadStateCanceled
 }
 
 // Upload represents the process of full or partial upload of data from a source, eventually represented as an upload in storacha.
@@ -121,10 +107,9 @@ func (u *Upload) RootCID() cid.Cid {
 }
 
 func (u *Upload) Fail(errorMessage string) error {
-	if TerminatedState(u.state) {
+	if u.state == UploadStateCompleted {
 		return fmt.Errorf("cannot fail upload in state %s", u.state)
 	}
-	u.state = UploadStateFailed
 	u.errorMessage = &errorMessage
 	u.updatedAt = time.Now()
 	return nil
@@ -141,13 +126,7 @@ func (u *Upload) Complete() error {
 }
 
 func (u *Upload) Cancel() error {
-	if TerminatedState(u.state) {
-		return fmt.Errorf("cannot cancel upload in state %s", u.state)
-	}
-	u.state = UploadStateCanceled
-	u.errorMessage = nil
-	u.updatedAt = time.Now()
-	return nil
+	return u.Fail("upload was canceled")
 }
 
 func (u *Upload) Start() error {
@@ -182,18 +161,6 @@ func (u *Upload) DAGGenerationComplete(rootCID cid.Cid) error {
 	return nil
 }
 
-func (u *Upload) Restart() error {
-	if !RestartableState(u.state) {
-		return fmt.Errorf("cannot restart upload in state %s", u.state)
-	}
-	u.state = UploadStatePending
-	u.rootFSEntryID = nil // Reset root file system entry ID
-	u.rootCID = cid.Undef // Reset root CID if applicable
-	u.errorMessage = nil
-	u.updatedAt = time.Now()
-	return nil
-}
-
 func validateUpload(upload *Upload) error {
 	if upload.id == id.Nil {
 		return types.ErrEmpty{Field: "upload ID"}
@@ -209,9 +176,6 @@ func validateUpload(upload *Upload) error {
 	}
 	if !validUploadState(upload.state) {
 		return fmt.Errorf("invalid upload state: %s", upload.state)
-	}
-	if upload.errorMessage != nil && upload.state != UploadStateFailed {
-		return fmt.Errorf("error message is set but upload state is not 'failed': %s", upload.state)
 	}
 	if upload.rootFSEntryID != nil && (upload.state == UploadStatePending || upload.state == UploadStateStarted) {
 		return fmt.Errorf("root file system entry ID is set but upload has not completed file system scan")

--- a/pkg/preparation/uploads/model/upload.go
+++ b/pkg/preparation/uploads/model/upload.go
@@ -139,23 +139,13 @@ func (u *Upload) Start() error {
 	return nil
 }
 
-func (u *Upload) ScanComplete(rootFSEntryID id.FSEntryID) error {
-	if u.state != UploadStateStarted {
-		return fmt.Errorf("cannot complete scan in state %s", u.state)
-	}
-	u.state = UploadStateScanned
-	u.errorMessage = nil
+func (u *Upload) SetRootFSEntryID(rootFSEntryID id.FSEntryID) error {
 	u.rootFSEntryID = &rootFSEntryID
 	u.updatedAt = time.Now()
 	return nil
 }
 
-func (u *Upload) DAGGenerationComplete(rootCID cid.Cid) error {
-	if u.state != UploadStateScanned {
-		return fmt.Errorf("cannot complete DAG generation in state %s", u.state)
-	}
-	u.state = UploadStateDagged
-	u.errorMessage = nil
+func (u *Upload) SetRootCID(rootCID cid.Cid) error {
 	u.rootCID = rootCID
 	u.updatedAt = time.Now()
 	return nil

--- a/pkg/preparation/uploads/model/upload.go
+++ b/pkg/preparation/uploads/model/upload.go
@@ -221,19 +221,3 @@ func ReadUploadFromDatabase(scanner UploadScanner) (*Upload, error) {
 
 	return &upload, nil
 }
-
-func (u *Upload) NeedsStart() bool {
-	return u.state == UploadStatePending
-}
-
-func (u *Upload) NeedsScan() bool {
-	return u.state == UploadStatePending || u.state == UploadStateStarted
-}
-
-func (u *Upload) NeedsDagScan() bool {
-	return u.state == UploadStatePending || u.state == UploadStateStarted || u.state == UploadStateScanned
-}
-
-func (u *Upload) NeedsUpload() bool {
-	return u.state == UploadStatePending || u.state == UploadStateStarted || u.state == UploadStateScanned || u.state == UploadStateDagged
-}

--- a/pkg/preparation/uploads/repo.go
+++ b/pkg/preparation/uploads/repo.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/storacha/go-ucanto/did"
 	dagmodel "github.com/storacha/guppy/pkg/preparation/dags/model"
+	scanmodel "github.com/storacha/guppy/pkg/preparation/scans/model"
 	"github.com/storacha/guppy/pkg/preparation/types/id"
 	uploadmodel "github.com/storacha/guppy/pkg/preparation/uploads/model"
 )
@@ -26,6 +27,8 @@ type Repo interface {
 	CreateDAGScan(ctx context.Context, fsEntryID id.FSEntryID, isDirectory bool, uploadID id.UploadID, spaceDID did.DID) (dagmodel.DAGScan, error)
 	// ListSpaceSources lists all space sources for the given space DID.
 	ListSpaceSources(ctx context.Context, spaceDID did.DID) ([]id.SourceID, error)
+	// CreateScan creates a new scan for an upload.
+	CreateScan(ctx context.Context, uploadID id.UploadID) (*scanmodel.Scan, error)
 }
 
 // IncompleteDagScanError is returned by CIDForFSEntry when the DAG scan for the file system entry is not completed.

--- a/pkg/preparation/uploads/uploads.go
+++ b/pkg/preparation/uploads/uploads.go
@@ -153,7 +153,7 @@ func (e *executor) runStartWorker(ctx context.Context, uploadAvailable <-chan st
 
 		// doWork
 		func() error {
-			if e.upload.NeedsStart() {
+			if e.upload.State() == model.UploadStatePending {
 				if err := e.upload.Start(); err != nil {
 					return fmt.Errorf("starting upload: %w", err)
 				}

--- a/pkg/preparation/uploads/uploads.go
+++ b/pkg/preparation/uploads/uploads.go
@@ -9,6 +9,7 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/storacha/go-ucanto/did"
 	dagmodel "github.com/storacha/guppy/pkg/preparation/dags/model"
+	scanmodel "github.com/storacha/guppy/pkg/preparation/scans/model"
 	"github.com/storacha/guppy/pkg/preparation/types/id"
 	"github.com/storacha/guppy/pkg/preparation/uploads/model"
 	"golang.org/x/sync/errgroup"
@@ -16,18 +17,16 @@ import (
 
 var log = logging.Logger("preparation/uploads")
 
-type RunNewScanFunc func(ctx context.Context, uploadID id.UploadID, fsEntryCb func(id id.FSEntryID, isDirectory bool) error) (id.FSEntryID, error)
-type RunDagScansForUploadFunc func(ctx context.Context, uploadID id.UploadID, nodeCB func(node dagmodel.Node, data []byte) error) error
-type RestartDagScansForUploadFunc func(ctx context.Context, uploadID id.UploadID) error
+type ExecuteScansForUploadFunc func(ctx context.Context, uploadID id.UploadID, nodeCB func(node scanmodel.FSEntry) error) error
+type ExecuteDagScansForUploadFunc func(ctx context.Context, uploadID id.UploadID, nodeCB func(node dagmodel.Node, data []byte) error) error
 type AddNodeToUploadShardsFunc func(ctx context.Context, uploadID id.UploadID, nodeCID cid.Cid) (bool, error)
 type CloseUploadShardsFunc func(ctx context.Context, uploadID id.UploadID) (bool, error)
 type SpaceBlobAddShardsForUploadFunc func(ctx context.Context, uploadID id.UploadID) error
 
 type API struct {
 	Repo                        Repo
-	RunNewScan                  RunNewScanFunc
-	RunDagScansForUpload        RunDagScansForUploadFunc
-	RestartDagScansForUpload    RestartDagScansForUploadFunc
+	ExecuteScansForUpload       ExecuteScansForUploadFunc
+	ExecuteDagScansForUpload    ExecuteDagScansForUploadFunc
 	SpaceBlobAddShardsForUpload SpaceBlobAddShardsForUploadFunc
 
 	// AddNodeToUploadShards adds a node to the upload's shards, creating a new
@@ -82,11 +81,11 @@ type executor struct {
 	api    API
 }
 
-// signalWorkAvailable signals on a channel that work is available. The channel
+// signal signals on a channel that work is available. The channel
 // should be buffered (generally with a size of 1). If the channel is full, it
 // will not block, as no further signal is needed: two messages saying that work
 // is available are the same as one.
-func signalWorkAvailable(work chan<- struct{}) {
+func signal(work chan<- struct{}) {
 	select {
 	case work <- struct{}{}:
 	default:
@@ -98,35 +97,27 @@ func (e executor) execute(ctx context.Context) (cid.Cid, error) {
 	log.Debugf("Executing upload %s in state %s", e.upload.ID(), e.upload.State())
 
 	eg, ctx := errgroup.WithContext(ctx)
-	dagWork := make(chan struct{}, 1)
-	blobWork := make(chan struct{}, 1)
 
-	// This one is just marking it as started, so it can be synchronous.
-	if e.upload.NeedsStart() {
-		if err := e.upload.Start(); err != nil {
-			return cid.Undef, fmt.Errorf("starting scan: %w", err)
-		}
-		if err := e.api.Repo.UpdateUpload(ctx, e.upload); err != nil {
-			return cid.Undef, fmt.Errorf("updating upload: %w", err)
-		}
-	}
+	var (
+		uploadAvailable       = make(chan struct{}, 1)
+		scansAvailable        = make(chan struct{}, 1)
+		dagScansAvailable     = make(chan struct{}, 1)
+		closedShardsAvailable = make(chan struct{}, 1)
+	)
 
-	// start the workers for all states not yet handled
-	if e.upload.NeedsScan() {
-		eg.Go(func() error {
-			return e.runScanWorker(ctx, dagWork)
-		})
-	}
-	if e.upload.NeedsDagScan() {
-		eg.Go(func() error {
-			return e.runDAGScanWorker(ctx, dagWork, blobWork)
-		})
-	}
-	if e.upload.NeedsUpload() {
-		eg.Go(func() error {
-			return e.runSpaceBlobAddWorker(ctx, blobWork)
-		})
-	}
+	// Start the workers
+	eg.Go(func() error { return e.runStartWorker(ctx, uploadAvailable, scansAvailable) })
+	eg.Go(func() error { return e.runScanWorker(ctx, scansAvailable, dagScansAvailable) })
+	eg.Go(func() error { return e.runDAGScanWorker(ctx, dagScansAvailable, closedShardsAvailable) })
+	eg.Go(func() error { return e.runSpaceBlobAddWorker(ctx, closedShardsAvailable) })
+
+	// Kick them all off. There may be work available in the DB from a previous
+	// attempt.
+	signal(uploadAvailable)
+	signal(scansAvailable)
+	signal(dagScansAvailable)
+	signal(closedShardsAvailable)
+	close(uploadAvailable)
 
 	log.Debugf("Waiting for workers to finish for upload %s", e.upload.ID())
 	err := eg.Wait()
@@ -153,58 +144,87 @@ func (e executor) execute(ctx context.Context) (cid.Cid, error) {
 	return e.upload.RootCID(), err
 }
 
-func (e *executor) runScanWorker(ctx context.Context, dagWork chan<- struct{}) error {
-	log.Debugf("Running new scan for upload %s in state %s", e.upload.ID(), e.upload.State())
+// runStartWorker runs the worker that creates the scan and signals that it's
+// available to run.
+func (e *executor) runStartWorker(ctx context.Context, uploadAvailable <-chan struct{}, scansAvailable chan<- struct{}) error {
+	return Worker(
+		ctx,
+		uploadAvailable,
 
-	// Unlike later stages, this one doesn't need to watch a work channel with
-	// [Worker], because it never has to wait for work.
+		// doWork
+		func() error {
+			if e.upload.NeedsStart() {
+				if err := e.upload.Start(); err != nil {
+					return fmt.Errorf("starting upload: %w", err)
+				}
+				if err := e.api.Repo.UpdateUpload(ctx, e.upload); err != nil {
+					return fmt.Errorf("updating upload: %w", err)
+				}
+				if _, err := e.api.Repo.CreateScan(ctx, e.upload.ID()); err != nil {
+					return fmt.Errorf("creating scan for upload %s: %w", e.upload.ID(), err)
+				}
+				signal(scansAvailable)
+			}
 
-	fsEntryID, err := e.api.RunNewScan(ctx, e.upload.ID(), func(id id.FSEntryID, isDirectory bool) error {
-		_, err := e.api.Repo.CreateDAGScan(ctx, id, isDirectory, e.upload.ID(), e.upload.SpaceDID())
-		if err != nil {
-			return fmt.Errorf("creating DAG scan: %w", err)
-		}
-		signalWorkAvailable(dagWork)
-		return nil
-	})
+			return nil
+		},
 
-	if err != nil {
-		return fmt.Errorf("running new scan: %w", err)
-	}
+		// finalize
+		func() error {
+			close(scansAvailable)
+			return nil
+		},
+	)
+}
 
-	// check if scan completed successfully
-	if fsEntryID == id.Nil {
-		return errors.New("scan did not complete successfully")
-	}
+func (e *executor) runScanWorker(ctx context.Context, scansAvailable <-chan struct{}, dagScansAvailable chan<- struct{}) error {
+	return Worker(
+		ctx,
+		scansAvailable,
 
-	log.Debugf("Scan completed successfully, root fs entry ID: %s", fsEntryID)
-	close(dagWork) // close the work channel to signal completion
+		// doWork
+		func() error {
+			err := e.api.ExecuteScansForUpload(ctx, e.upload.ID(), func(entry scanmodel.FSEntry) error {
+				if entry.Path() == "." {
+					e.upload.SetRootFSEntryID(entry.ID())
+					if err := e.api.Repo.UpdateUpload(ctx, e.upload); err != nil {
+						return fmt.Errorf("updating upload: %w", err)
+					}
+				}
+				_, isDirectory := entry.(*scanmodel.Directory)
+				_, err := e.api.Repo.CreateDAGScan(ctx, entry.ID(), isDirectory, e.upload.ID(), e.upload.SpaceDID())
+				if err != nil {
+					return fmt.Errorf("creating DAG scan: %w", err)
+				}
+				signal(dagScansAvailable)
+				return nil
+			})
 
-	if err := e.upload.ScanComplete(fsEntryID); err != nil {
-		return fmt.Errorf("completing scan: %w", err)
-	}
-	if err := e.api.Repo.UpdateUpload(ctx, e.upload); err != nil {
-		return fmt.Errorf("updating upload: %w", err)
-	}
+			if err != nil {
+				return fmt.Errorf("running scans: %w", err)
+			}
 
-	return nil
+			return nil
+		},
+
+		// finalize
+		func() error {
+			close(dagScansAvailable)
+			return nil
+		},
+	)
 }
 
 // runDAGScanWorker runs the worker that scans files and directories into blocks,
 // and buckets them into shards.
-func (e *executor) runDAGScanWorker(ctx context.Context, dagWork <-chan struct{}, blobWork chan<- struct{}) error {
-	err := e.api.RestartDagScansForUpload(ctx, e.upload.ID())
-	if err != nil {
-		return fmt.Errorf("restarting scans for upload %s: %w", e.upload.ID(), err)
-	}
-
+func (e *executor) runDAGScanWorker(ctx context.Context, dagScansAvailable <-chan struct{}, closedShardsAvailable chan<- struct{}) error {
 	return Worker(
 		ctx,
-		dagWork,
+		dagScansAvailable,
 
 		// doWork
 		func() error {
-			err := e.api.RunDagScansForUpload(ctx, e.upload.ID(), func(node dagmodel.Node, data []byte) error {
+			err := e.api.ExecuteDagScansForUpload(ctx, e.upload.ID(), func(node dagmodel.Node, data []byte) error {
 				log.Debugf("Adding node %s to upload shards for upload %s", node.CID(), e.upload.ID())
 				shardClosed, err := e.api.AddNodeToUploadShards(ctx, e.upload.ID(), node.CID())
 				if err != nil {
@@ -212,7 +232,7 @@ func (e *executor) runDAGScanWorker(ctx context.Context, dagWork <-chan struct{}
 				}
 
 				if shardClosed {
-					signalWorkAvailable(blobWork)
+					signal(closedShardsAvailable)
 				}
 
 				return nil
@@ -227,6 +247,18 @@ func (e *executor) runDAGScanWorker(ctx context.Context, dagWork <-chan struct{}
 
 		// finalize
 		func() error {
+			// We're out of nodes, so we can close any open shards for this upload.
+			shardClosed, err := e.api.CloseUploadShards(ctx, e.upload.ID())
+			if err != nil {
+				return fmt.Errorf("closing upload shards for upload %s: %w", e.upload.ID(), err)
+			}
+
+			if shardClosed {
+				signal(closedShardsAvailable)
+			}
+
+			close(closedShardsAvailable)
+
 			rootCid, err := e.api.Repo.CIDForFSEntry(ctx, e.upload.RootFSEntryID())
 			if err != nil {
 				var incompleteErr IncompleteDagScanError
@@ -240,19 +272,7 @@ func (e *executor) runDAGScanWorker(ctx context.Context, dagWork <-chan struct{}
 				return fmt.Errorf("retrieving CID for root fs entry: %w", err)
 			}
 
-			// We're out of nodes, so we can close any open shards for this upload.
-			shardClosed, err := e.api.CloseUploadShards(ctx, e.upload.ID())
-			if err != nil {
-				return fmt.Errorf("closing upload shards for upload %s: %w", e.upload.ID(), err)
-			}
-
-			if shardClosed {
-				signalWorkAvailable(blobWork)
-			}
-
-			close(blobWork) // close the work channel to signal completion
-
-			if err := e.upload.DAGGenerationComplete(rootCid); err != nil {
+			if err := e.upload.SetRootCID(rootCid); err != nil {
 				return fmt.Errorf("completing DAG generation: %w", err)
 			}
 			if err := e.api.Repo.UpdateUpload(ctx, e.upload); err != nil {
@@ -274,7 +294,6 @@ func (e *executor) runSpaceBlobAddWorker(ctx context.Context, blobWork <-chan st
 		// doWork
 		func() error {
 			err := e.api.SpaceBlobAddShardsForUpload(ctx, e.upload.ID())
-
 			if err != nil {
 				return fmt.Errorf("`space/blob/add`ing shards for upload %s: %w", e.upload.ID(), err)
 			}


### PR DESCRIPTION
Big changes here!

* Adjusted the workers/APIs/domains to be much more consistent.
* Removed most of the upload states. An upload is now either pending or started. If an upload is started, it's failed if it has an error message, and it's successful if it has a `rootCID`. The state of the file scans, DAG scans, and shards are in those models.

Now, if the process fails at any point, the data remains frozen in the intermediate state it failed in, and can be restarted from there.

Notably, this does *not* directly address the underlying data on disk changing during the process, but that should also be easier to deal with now, as we can simply delete facts from the DB that we know are no longer true and idempotently throw the whole process at it again. But doing that is still for a future PR.








#### PR Dependency Tree


* **PR #112** 👈
  * **PR #115**
    * **PR #116**
      * **PR #117**
        * **PR #118**
          * **PR #124**
            * **PR #125**
              * **PR #126**
                * **PR #127**
                  * **PR #128**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)