### PR TITLE
feat: `upload/add` at end of upload

### DIFF
--- a/pkg/preparation/internal/mockclient/mockclient.go
+++ b/pkg/preparation/internal/mockclient/mockclient.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipld/go-ipld-prime"
 	"github.com/multiformats/go-multihash"
+	"github.com/storacha/go-libstoracha/capabilities/upload"
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/guppy/pkg/client"
@@ -19,6 +20,7 @@ type MockClient struct {
 	T                        *testing.T
 	SpaceBlobAddInvocations  []spaceBlobAddInvocation
 	SpaceIndexAddInvocations []spaceIndexAddInvocation
+	UploadAddInvocations     []uploadAddInvocation
 }
 
 type spaceBlobAddInvocation struct {
@@ -29,6 +31,12 @@ type spaceBlobAddInvocation struct {
 type spaceIndexAddInvocation struct {
 	Space     did.DID
 	IndexLink ipld.Link
+}
+
+type uploadAddInvocation struct {
+	Space  did.DID
+	Root   ipld.Link
+	Shards []ipld.Link
 }
 
 var _ storacha.Client = (*MockClient)(nil)
@@ -53,4 +61,14 @@ func (m *MockClient) SpaceIndexAdd(ctx context.Context, indexLink ipld.Link, spa
 	})
 
 	return nil
+}
+
+func (m *MockClient) UploadAdd(ctx context.Context, space did.DID, root ipld.Link, shards []ipld.Link) (upload.AddOk, error) {
+	m.UploadAddInvocations = append(m.UploadAddInvocations, uploadAddInvocation{
+		Space:  space,
+		Root:   root,
+		Shards: shards,
+	})
+
+	return upload.AddOk{Root: root, Shards: shards}, nil
 }

--- a/pkg/preparation/preparation.go
+++ b/pkg/preparation/preparation.go
@@ -137,6 +137,7 @@ func NewAPI(repo Repo, client StorachaClient, space did.DID, options ...Option) 
 		CloseUploadShards:           shardsAPI.CloseUploadShards,
 		SpaceBlobAddShardsForUpload: storachaAPI.SpaceBlobAddShardsForUpload,
 		AddIndexesForUpload:         storachaAPI.AddIndexesForUpload,
+		AddStorachaUploadForUpload:  storachaAPI.AddStorachaUploadForUpload,
 	}
 
 	return API{

--- a/pkg/preparation/preparation_test.go
+++ b/pkg/preparation/preparation_test.go
@@ -19,6 +19,7 @@ import (
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-car/v2/blockstore"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -27,6 +28,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/storacha/go-libstoracha/blobindex"
 	spaceindexcap "github.com/storacha/go-libstoracha/capabilities/space/index"
+	uploadcap "github.com/storacha/go-libstoracha/capabilities/upload"
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/receipt/fx"
@@ -72,14 +74,23 @@ func (c *putTrackingClient) SpaceBlobAdd(ctx context.Context, content io.Reader,
 }
 
 // prepareTestClient creates a new test [storacha.Client] that uses the given
-// [http.Client] as the client for PUT requests, and stores the index link from
-// the `space/index/add` invocation in the given [indexLink] pointer. The
-// returned function returns the blobs received by the PUT client, and the index
-// link.
-func prepareTestClient(t *testing.T, space principal.Signer, putClient *http.Client, indexLink *ipld.Link) *putTrackingClient {
+// [http.Client] as the client for PUT requests, stores the index link from the
+// `space/index/add` invocation in the given [indexLink] pointer, and stores the
+// root link and shard links from the `upload/add` in the [rootLink] and
+// [shardLinks] pointers, respectively. The returned function returns the blobs
+// received by the PUT client, and the index link.
+func prepareTestClient(
+	t *testing.T,
+	space principal.Signer,
+	putClient *http.Client,
+	indexLink *ipld.Link,
+	rootLink *ipld.Link,
+	shardLinks *[]ipld.Link,
+) *putTrackingClient {
 	client := &putTrackingClient{
 		Client: helpers.Must(ctestutil.Client(
 			ctestutil.WithSpaceBlobAdd(),
+
 			ctestutil.WithServerOptions(
 				server.WithServiceMethod(
 					spaceindexcap.Add.Can(),
@@ -95,6 +106,30 @@ func prepareTestClient(t *testing.T, space principal.Signer, putClient *http.Cli
 							assert.Nil(t, *indexLink, "expected only one `space/index/add` invocation")
 							*indexLink = cap.Nb().Index
 							return result.Ok[spaceindexcap.AddOk, failure.IPLDBuilderFailure](spaceindexcap.AddOk{}), nil, nil
+						},
+					),
+				),
+			),
+
+			ctestutil.WithServerOptions(
+				server.WithServiceMethod(
+					uploadcap.Add.Can(),
+					server.Provide(
+						uploadcap.Add,
+						func(
+							ctx context.Context,
+							cap ucan.Capability[uploadcap.AddCaveats],
+							inv invocation.Invocation,
+							context server.InvocationContext,
+						) (result.Result[uploadcap.AddOk, failure.IPLDBuilderFailure], fx.Effects, error) {
+							assert.Equal(t, space.DID().String(), cap.With(), "expected `upload/add` invocation to be for the correct space")
+							assert.Nil(t, *rootLink, "expected only one `upload/add` invocation")
+							*rootLink = cap.Nb().Root
+							*shardLinks = cap.Nb().Shards
+							return result.Ok[uploadcap.AddOk, failure.IPLDBuilderFailure](uploadcap.AddOk{
+								Root:   cap.Nb().Root,
+								Shards: cap.Nb().Shards,
+							}), nil, nil
 						},
 					),
 				),
@@ -144,7 +179,9 @@ func TestExecuteUpload(t *testing.T) {
 
 		putClient := ctestutil.NewPutClient()
 		var indexLink ipld.Link
-		c := prepareTestClient(t, space, putClient, &indexLink)
+		var rootLink ipld.Link
+		var shardLinks []ipld.Link
+		c := prepareTestClient(t, space, putClient, &indexLink, &rootLink, &shardLinks)
 
 		api := preparation.NewAPI(
 			repo,
@@ -158,14 +195,20 @@ func TestExecuteUpload(t *testing.T) {
 
 		upload := createUpload(t, repo, space.DID(), api)
 
-		rootCid, err := api.ExecuteUpload(t.Context(), upload)
+		returnedRootCid, err := api.ExecuteUpload(t.Context(), upload)
 		require.NoError(t, err)
 
 		putBlobs := ctestutil.ReceivedBlobs(putClient)
 		require.Equal(t, putBlobs.Size(), 6, "expected 5 shards + 1 index to be added")
 		require.NotNil(t, indexLink, "expected `space/index/add` to be called")
+		indexCIDLink, ok := indexLink.(cidlink.Link)
+		require.True(t, ok, "expected index link to be a CID link")
+		require.NotNil(t, rootLink, "expected `upload/add` to be called")
+		rootCIDLink, ok := rootLink.(cidlink.Link)
+		require.True(t, ok, "expected root link to be a CID link")
+		require.Equal(t, rootLink.(cidlink.Link).Cid, returnedRootCid, "expected returned root CID to match the one in the `upload/add`")
 
-		foundData := filesData(t.Context(), t, rootCid, indexLink, putBlobs)
+		foundData := filesData(t.Context(), t, rootCIDLink.Cid, indexCIDLink.Cid, putBlobs)
 
 		// Don't do this directly in the assertion, because if it fails, we don't want
 		// to try to print all of that data.
@@ -178,6 +221,9 @@ func TestExecuteUpload(t *testing.T) {
 	})
 
 	t.Run("after an error, can be retried safely", func(t *testing.T) {
+		// Hide the error we're about to cause from the logs.
+		logging.SetLogLevel("preparation/uploads", "dpanic")
+
 		space, err := signer.Generate()
 		require.NoError(t, err)
 
@@ -207,7 +253,9 @@ func TestExecuteUpload(t *testing.T) {
 		}
 
 		var indexLink ipld.Link
-		c := prepareTestClient(t, space, putClient, &indexLink)
+		var rootLink ipld.Link
+		var shardLinks []ipld.Link
+		c := prepareTestClient(t, space, putClient, &indexLink, &rootLink, &shardLinks)
 
 		api := preparation.NewAPI(
 			repo,
@@ -227,15 +275,23 @@ func TestExecuteUpload(t *testing.T) {
 
 		putBlobs := ctestutil.ReceivedBlobs(putClient)
 		require.Equal(t, 2, putBlobs.Size(), "expected only 2 shards to be added so far")
+		require.Nil(t, indexLink, "expected `space/index/add` not to have been called yet")
+		require.Nil(t, rootLink, "expected `upload/add` not to have been called yet")
+		require.Nil(t, shardLinks, "expected `upload/add` not to have been called yet")
 
 		// The second time, it should succeedfs
-		rootCid, err := api.ExecuteUpload(t.Context(), upload)
+		returnedRootCid, err := api.ExecuteUpload(t.Context(), upload)
 		require.NoError(t, err, "expected upload to succeed on retry")
 
 		putBlobs = ctestutil.ReceivedBlobs(putClient)
 		require.Equal(t, 6, putBlobs.Size(), "expected 5 shards + 1 index to be added in the end")
+		rootCIDLink, ok := rootLink.(cidlink.Link)
+		require.True(t, ok, "expected root link to be a CID link")
+		indexCIDLink, ok := indexLink.(cidlink.Link)
+		require.True(t, ok, "expected index link to be a CID link")
+		require.Equal(t, rootLink.(cidlink.Link).Cid, returnedRootCid, "expected returned root CID to match the one in the `upload/add`")
 
-		foundData := filesData(t.Context(), t, rootCid, indexLink, putBlobs)
+		foundData := filesData(t.Context(), t, rootCIDLink.Cid, indexCIDLink.Cid, putBlobs)
 
 		// Don't do this directly in the assertion, because if it fails, we don't want
 		// to try to print all of that data.
@@ -273,8 +329,8 @@ func prepareFs(t *testing.T, files map[string][]byte) afero.IOFS {
 	return memIOFS
 }
 
-func filesData(ctx context.Context, t *testing.T, rootCid cid.Cid, indexLink ipld.Link, shards ctestutil.BlobMap) map[string][]byte {
-	bs, err := newIndexAndShardsBlockstore(indexLink, shards)
+func filesData(ctx context.Context, t *testing.T, rootCid cid.Cid, indexCid cid.Cid, shards ctestutil.BlobMap) map[string][]byte {
+	bs, err := newIndexAndShardsBlockstore(indexCid, shards)
 	require.NoError(t, err)
 
 	blockserv := blockservice.New(bs, nil)
@@ -311,19 +367,14 @@ type indexAndShardsBlockstore struct {
 
 var _ blockstore.Blockstore = (*indexAndShardsBlockstore)(nil)
 
-func newIndexAndShardsBlockstore(indexLink ipld.Link, shards ctestutil.BlobMap) (*indexAndShardsBlockstore, error) {
-	indexCidLink, ok := indexLink.(cidlink.Link)
-	if !ok {
-		return nil, fmt.Errorf("expected index link to be a cidlink.Link, got %T", indexLink)
+func newIndexAndShardsBlockstore(indexCid cid.Cid, shards ctestutil.BlobMap) (*indexAndShardsBlockstore, error) {
+	if indexCid.Prefix().Codec != uint64(multicodec.Car) {
+		return nil, fmt.Errorf("expected index link CID to have codec 0x%x (CAR), got 0x%x", multicodec.Car, indexCid.Prefix().Codec)
 	}
 
-	if indexCidLink.Prefix().Codec != uint64(multicodec.Car) {
-		return nil, fmt.Errorf("expected index link CID to have codec 0x%x (CAR), got 0x%x", multicodec.Car, indexCidLink.Cid.Prefix().Codec)
-	}
-
-	indexDigest := indexCidLink.Hash()
+	indexDigest := indexCid.Hash()
 	if !shards.Has(indexDigest) {
-		return nil, fmt.Errorf("index CID %s (digest %s) not found in provided shards", indexCidLink.Cid, indexDigest.B58String())
+		return nil, fmt.Errorf("index CID %s (digest %s) not found in provided shards", indexCid, indexDigest.B58String())
 	}
 
 	index, err := blobindex.Extract(bytes.NewReader(shards.Get(indexDigest)))

--- a/pkg/preparation/sqlrepo/scans.go
+++ b/pkg/preparation/sqlrepo/scans.go
@@ -16,10 +16,10 @@ import (
 	"github.com/storacha/guppy/pkg/preparation/types/id"
 )
 
-var _ scans.Repo = (*repo)(nil)
+var _ scans.Repo = (*Repo)(nil)
 
 // CreateScan creates a new scan in the repository with the given upload ID.
-func (r *repo) CreateScan(ctx context.Context, uploadID id.UploadID) (*scanmodel.Scan, error) {
+func (r *Repo) CreateScan(ctx context.Context, uploadID id.UploadID) (*scanmodel.Scan, error) {
 	scan, err := scanmodel.NewScan(uploadID)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (r *repo) CreateScan(ctx context.Context, uploadID id.UploadID) (*scanmodel
 	return scan, nil
 }
 
-func (r *repo) GetScanByID(ctx context.Context, scanID id.ScanID) (*scanmodel.Scan, error) {
+func (r *Repo) GetScanByID(ctx context.Context, scanID id.ScanID) (*scanmodel.Scan, error) {
 	row := r.db.QueryRowContext(ctx,
 		`SELECT
 			id,
@@ -120,7 +120,7 @@ func (r *repo) GetScanByID(ctx context.Context, scanID id.ScanID) (*scanmodel.Sc
 // ScansForUploadByStatus retrieves all scans for a given upload ID matching the
 // given states, if given, or all if no states are provided. Because an upload
 // normally has at most one scan, this will return at most one scan.
-func (r *repo) ScansForUploadByStatus(ctx context.Context, uploadID id.UploadID, states ...model.ScanState) ([]*model.Scan, error) {
+func (r *Repo) ScansForUploadByStatus(ctx context.Context, uploadID id.UploadID, states ...model.ScanState) ([]*model.Scan, error) {
 	query :=
 		`SELECT
 			id,
@@ -181,7 +181,7 @@ func (r *repo) ScansForUploadByStatus(ctx context.Context, uploadID id.UploadID,
 // FindOrCreateFile finds or creates a file entry in the repository with the given parameters.
 // If the file already exists, it returns the existing file and false.
 // If the file does not exist, it creates a new file entry and returns it along with true.
-func (r *repo) FindOrCreateFile(ctx context.Context, path string, lastModified time.Time, mode fs.FileMode, size uint64, checksum []byte, sourceID id.SourceID, spaceDID did.DID) (*scanmodel.File, bool, error) {
+func (r *Repo) FindOrCreateFile(ctx context.Context, path string, lastModified time.Time, mode fs.FileMode, size uint64, checksum []byte, sourceID id.SourceID, spaceDID did.DID) (*scanmodel.File, bool, error) {
 	if mode.IsDir() {
 		return nil, false, errors.New("cannot create a file with directory mode")
 	}
@@ -214,7 +214,7 @@ func (r *repo) FindOrCreateFile(ctx context.Context, path string, lastModified t
 // FindOrCreateDirectory finds or creates a directory entry in the repository with the given parameters.
 // If the directory already exists, it returns the existing directory and false.
 // If the directory does not exist, it creates a new directory entry and returns it along with true.
-func (r *repo) FindOrCreateDirectory(ctx context.Context, path string, lastModified time.Time, mode fs.FileMode, checksum []byte, sourceID id.SourceID, spaceDID did.DID) (*scanmodel.Directory, bool, error) {
+func (r *Repo) FindOrCreateDirectory(ctx context.Context, path string, lastModified time.Time, mode fs.FileMode, checksum []byte, sourceID id.SourceID, spaceDID did.DID) (*scanmodel.Directory, bool, error) {
 	log.Debugf("Finding or creating directory: %s", path)
 	if !mode.IsDir() {
 		return nil, false, errors.New("cannot create a directory with file mode")
@@ -246,7 +246,7 @@ func (r *repo) FindOrCreateDirectory(ctx context.Context, path string, lastModif
 }
 
 // CreateDirectoryChildren links a directory to its children in the repository.
-func (r *repo) CreateDirectoryChildren(ctx context.Context, parent *scanmodel.Directory, children []scanmodel.FSEntry) error {
+func (r *Repo) CreateDirectoryChildren(ctx context.Context, parent *scanmodel.Directory, children []scanmodel.FSEntry) error {
 	insertQuery := `
 		INSERT INTO directory_children (directory_id, child_id)
 		VALUES ($1, $2)
@@ -263,7 +263,7 @@ func (r *repo) CreateDirectoryChildren(ctx context.Context, parent *scanmodel.Di
 }
 
 // DirectoryChildren retrieves the children of a directory from the repository.
-func (r *repo) DirectoryChildren(ctx context.Context, dir *scanmodel.Directory) ([]scanmodel.FSEntry, error) {
+func (r *Repo) DirectoryChildren(ctx context.Context, dir *scanmodel.Directory) ([]scanmodel.FSEntry, error) {
 	query := `
 		SELECT fse.id, fse.path, fse.last_modified, fse.mode, fse.size, fse.checksum, fse.source_id, fse.space_did
 		FROM directory_children dc
@@ -308,7 +308,7 @@ func (r *repo) DirectoryChildren(ctx context.Context, dir *scanmodel.Directory) 
 }
 
 // UpdateScan updates the given scan in the repository.
-func (r *repo) UpdateScan(ctx context.Context, scan *scanmodel.Scan) error {
+func (r *Repo) UpdateScan(ctx context.Context, scan *scanmodel.Scan) error {
 	query := `
 		UPDATE scans
 		SET upload_id = $2, root_id = $3, created_at = $4, updated_at = $5, state = $6, error_message = $7
@@ -322,7 +322,7 @@ func (r *repo) UpdateScan(ctx context.Context, scan *scanmodel.Scan) error {
 }
 
 // GetFileByID retrieves a file by its unique ID from the repository.
-func (r *repo) GetFileByID(ctx context.Context, fileID id.FSEntryID) (*scanmodel.File, error) {
+func (r *Repo) GetFileByID(ctx context.Context, fileID id.FSEntryID) (*scanmodel.File, error) {
 	row := r.db.QueryRowContext(ctx,
 		`SELECT id, path, last_modified, mode, size, checksum, source_id, space_did FROM fs_entries WHERE id = ?`, fileID,
 	)
@@ -341,7 +341,7 @@ func (r *repo) GetFileByID(ctx context.Context, fileID id.FSEntryID) (*scanmodel
 	return nil, errors.New("found entry is not a file")
 }
 
-func (r *repo) findFSEntry(ctx context.Context, path string, lastModified time.Time, mode fs.FileMode, size uint64, checksum []byte, sourceID id.SourceID, spaceDID did.DID) (scanmodel.FSEntry, error) {
+func (r *Repo) findFSEntry(ctx context.Context, path string, lastModified time.Time, mode fs.FileMode, size uint64, checksum []byte, sourceID id.SourceID, spaceDID did.DID) (scanmodel.FSEntry, error) {
 	query := `
 		SELECT id, path, last_modified, mode, size, checksum, source_id, space_did
 		FROM fs_entries
@@ -391,7 +391,7 @@ func (r *repo) findFSEntry(ctx context.Context, path string, lastModified time.T
 	return entry, err
 }
 
-func (r *repo) createFSEntry(ctx context.Context, entry scanmodel.FSEntry) error {
+func (r *Repo) createFSEntry(ctx context.Context, entry scanmodel.FSEntry) error {
 	insertQuery := `
 		INSERT INTO fs_entries (id, path, last_modified, mode, size, checksum, source_id, space_did)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)

--- a/pkg/preparation/sqlrepo/shards.go
+++ b/pkg/preparation/sqlrepo/shards.go
@@ -16,9 +16,9 @@ import (
 	"github.com/storacha/guppy/pkg/preparation/types/id"
 )
 
-var _ shards.Repo = (*repo)(nil)
+var _ shards.Repo = (*Repo)(nil)
 
-func (r *repo) CreateShard(ctx context.Context, uploadID id.UploadID, size uint64) (*model.Shard, error) {
+func (r *Repo) CreateShard(ctx context.Context, uploadID id.UploadID, size uint64) (*model.Shard, error) {
 	shard, err := model.NewShard(uploadID, size)
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func (r *repo) CreateShard(ctx context.Context, uploadID id.UploadID, size uint6
 	return shard, nil
 }
 
-func (r *repo) ShardsForUploadByStatus(ctx context.Context, uploadID id.UploadID, state model.ShardState) ([]*model.Shard, error) {
+func (r *Repo) ShardsForUploadByStatus(ctx context.Context, uploadID id.UploadID, state model.ShardState) ([]*model.Shard, error) {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT
 			id,
@@ -95,7 +95,7 @@ func (r *repo) ShardsForUploadByStatus(ctx context.Context, uploadID id.UploadID
 	return shards, nil
 }
 
-func (r *repo) GetShardByID(ctx context.Context, shardID id.ShardID) (*model.Shard, error) {
+func (r *Repo) GetShardByID(ctx context.Context, shardID id.ShardID) (*model.Shard, error) {
 	row := r.db.QueryRowContext(ctx, `
 		SELECT
 			id,
@@ -130,7 +130,7 @@ func (r *repo) GetShardByID(ctx context.Context, shardID id.ShardID) (*model.Sha
 // of the length varint + the length of the CID bytes. The node's block will be
 // indexed as appearing at `shard.size + offset`, running for `node.size` bytes,
 // and then the shard size will be increased by `offset + node.size`.
-func (r *repo) AddNodeToShard(ctx context.Context, shardID id.ShardID, nodeCID cid.Cid, spaceDID did.DID, offset uint64) error {
+func (r *Repo) AddNodeToShard(ctx context.Context, shardID id.ShardID, nodeCID cid.Cid, spaceDID did.DID, offset uint64) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -168,7 +168,7 @@ func (r *repo) AddNodeToShard(ctx context.Context, shardID id.ShardID, nodeCID c
 	return tx.Commit()
 }
 
-func (r *repo) FindNodeByCidAndSpaceDID(ctx context.Context, c cid.Cid, spaceDID did.DID) (dagsmodel.Node, error) {
+func (r *Repo) FindNodeByCidAndSpaceDID(ctx context.Context, c cid.Cid, spaceDID did.DID) (dagsmodel.Node, error) {
 	findQuery := `
 		SELECT
 			cid,
@@ -190,7 +190,7 @@ func (r *repo) FindNodeByCidAndSpaceDID(ctx context.Context, c cid.Cid, spaceDID
 	return r.getNodeFromRow(row)
 }
 
-func (r *repo) ForEachNode(ctx context.Context, shardID id.ShardID, yield func(node dagsmodel.Node, shardOffset uint64) error) error {
+func (r *Repo) ForEachNode(ctx context.Context, shardID id.ShardID, yield func(node dagsmodel.Node, shardOffset uint64) error) error {
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT
 			nodes.cid,
@@ -231,7 +231,7 @@ func (r *repo) ForEachNode(ctx context.Context, shardID id.ShardID, yield func(n
 }
 
 // UpdateShard updates a DAG scan in the repository.
-func (r *repo) UpdateShard(ctx context.Context, shard *model.Shard) error {
+func (r *Repo) UpdateShard(ctx context.Context, shard *model.Shard) error {
 	return model.WriteShardToDatabase(shard, func(
 		id id.ShardID,
 		uploadID id.UploadID,

--- a/pkg/preparation/sqlrepo/sources.go
+++ b/pkg/preparation/sqlrepo/sources.go
@@ -13,10 +13,10 @@ import (
 	"github.com/storacha/guppy/pkg/preparation/types/id"
 )
 
-var _ sources.Repo = (*repo)(nil)
+var _ sources.Repo = (*Repo)(nil)
 
 // CreateSource creates a new source in the repository with the given name, path, and options.
-func (r *repo) CreateSource(ctx context.Context, name string, path string, options ...sourcemodel.SourceOption) (*sourcemodel.Source, error) {
+func (r *Repo) CreateSource(ctx context.Context, name string, path string, options ...sourcemodel.SourceOption) (*sourcemodel.Source, error) {
 	src, err := sourcemodel.NewSource(name, path, options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create source model: %w", err)
@@ -48,7 +48,7 @@ func (r *repo) CreateSource(ctx context.Context, name string, path string, optio
 }
 
 // GetSourceByID retrieves a source by its unique ID from the repository.
-func (r *repo) GetSourceByID(ctx context.Context, sourceID id.SourceID) (*sourcemodel.Source, error) {
+func (r *Repo) GetSourceByID(ctx context.Context, sourceID id.SourceID) (*sourcemodel.Source, error) {
 	row := r.db.QueryRowContext(ctx,
 		`SELECT
 			id,
@@ -65,7 +65,7 @@ func (r *repo) GetSourceByID(ctx context.Context, sourceID id.SourceID) (*source
 }
 
 // GetSourceByName retrieves a source by its name from the repository.
-func (r *repo) GetSourceByName(ctx context.Context, name string) (*sourcemodel.Source, error) {
+func (r *Repo) GetSourceByName(ctx context.Context, name string) (*sourcemodel.Source, error) {
 	row := r.db.QueryRowContext(ctx,
 		`SELECT
 			id,
@@ -81,7 +81,7 @@ func (r *repo) GetSourceByName(ctx context.Context, name string) (*sourcemodel.S
 	return r.getSourceFromRow(row)
 }
 
-func (r *repo) getSourceFromRow(row *sql.Row) (*sourcemodel.Source, error) {
+func (r *Repo) getSourceFromRow(row *sql.Row) (*sourcemodel.Source, error) {
 	src, err := sourcemodel.ReadSourceFromDatabase(func(
 		id *id.SourceID,
 		name *string,
@@ -113,7 +113,7 @@ func (r *repo) getSourceFromRow(row *sql.Row) (*sourcemodel.Source, error) {
 }
 
 // UpdateSource updates the given source in the repository.
-func (r *repo) UpdateSource(ctx context.Context, src *sourcemodel.Source) error {
+func (r *Repo) UpdateSource(ctx context.Context, src *sourcemodel.Source) error {
 	_, err := r.db.ExecContext(ctx,
 		`UPDATE sources SET name = ?, updated_at = ?, kind = ?, path = ?, connection_params = ? WHERE id = ?`,
 		src.Name(), src.UpdatedAt(), src.Kind(), src.Path(), src.ConnectionParams(), src.ID(),

--- a/pkg/preparation/sqlrepo/spaces.go
+++ b/pkg/preparation/sqlrepo/spaces.go
@@ -14,10 +14,10 @@ import (
 	"github.com/storacha/guppy/pkg/preparation/types/id"
 )
 
-var _ spaces.Repo = (*repo)(nil)
+var _ spaces.Repo = (*Repo)(nil)
 
 // FindOrCreateSpace finds an existing space or creates a new one in the repository with the given name and options.
-func (r *repo) FindOrCreateSpace(ctx context.Context, did did.DID, name string, options ...spacesmodel.SpaceOption) (*spacesmodel.Space, error) {
+func (r *Repo) FindOrCreateSpace(ctx context.Context, did did.DID, name string, options ...spacesmodel.SpaceOption) (*spacesmodel.Space, error) {
 	space, err := r.GetSpaceByDID(ctx, did)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get space by DID: %w", err)
@@ -49,7 +49,7 @@ func (r *repo) FindOrCreateSpace(ctx context.Context, did did.DID, name string, 
 }
 
 // GetSpaceByDID retrieves a space by its unique DID from the repository.
-func (r *repo) GetSpaceByDID(ctx context.Context, spaceDID did.DID) (*spacesmodel.Space, error) {
+func (r *Repo) GetSpaceByDID(ctx context.Context, spaceDID did.DID) (*spacesmodel.Space, error) {
 	row := r.db.QueryRowContext(ctx,
 		`SELECT
 			did,
@@ -62,7 +62,7 @@ func (r *repo) GetSpaceByDID(ctx context.Context, spaceDID did.DID) (*spacesmode
 }
 
 // GetSpaceByUploadID retrieves the space associated with an upload.
-func (r *repo) GetSpaceByUploadID(ctx context.Context, uploadID id.UploadID) (*spacesmodel.Space, error) {
+func (r *Repo) GetSpaceByUploadID(ctx context.Context, uploadID id.UploadID) (*spacesmodel.Space, error) {
 	row := r.db.QueryRowContext(ctx,
 		`SELECT
 			s.did,
@@ -77,7 +77,7 @@ func (r *repo) GetSpaceByUploadID(ctx context.Context, uploadID id.UploadID) (*s
 }
 
 // GetSpaceByName retrieves a space by its name from the repository.
-func (r *repo) GetSpaceByName(ctx context.Context, name string) (*spacesmodel.Space, error) {
+func (r *Repo) GetSpaceByName(ctx context.Context, name string) (*spacesmodel.Space, error) {
 	row := r.db.QueryRowContext(ctx,
 		`SELECT
 			did,
@@ -89,7 +89,7 @@ func (r *repo) GetSpaceByName(ctx context.Context, name string) (*spacesmodel.Sp
 	return r.getSpaceFromRow(row)
 }
 
-func (r *repo) getSpaceFromRow(row *sql.Row) (*spacesmodel.Space, error) {
+func (r *Repo) getSpaceFromRow(row *sql.Row) (*spacesmodel.Space, error) {
 	space, err := spacesmodel.ReadSpaceFromDatabase(func(
 		did *did.DID,
 		name *string,
@@ -110,7 +110,7 @@ func (r *repo) getSpaceFromRow(row *sql.Row) (*spacesmodel.Space, error) {
 }
 
 // DeleteSpace deletes a space from the repository.
-func (r *repo) DeleteSpace(ctx context.Context, spaceDID did.DID) error {
+func (r *Repo) DeleteSpace(ctx context.Context, spaceDID did.DID) error {
 	_, err := r.db.ExecContext(ctx,
 		`DELETE FROM spaces WHERE did = ?`,
 		util.DbDID(&spaceDID),
@@ -127,7 +127,7 @@ func (r *repo) DeleteSpace(ctx context.Context, spaceDID did.DID) error {
 }
 
 // ListSpaces lists all spaces in the repository.
-func (r *repo) ListSpaces(ctx context.Context) ([]*spacesmodel.Space, error) {
+func (r *Repo) ListSpaces(ctx context.Context) ([]*spacesmodel.Space, error) {
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT did, name, created_at, shard_size FROM spaces`,
 	)
@@ -153,7 +153,7 @@ func (r *repo) ListSpaces(ctx context.Context) ([]*spacesmodel.Space, error) {
 }
 
 // AddSourceToSpace adds a source to a space in the repository.
-func (r *repo) AddSourceToSpace(ctx context.Context, spaceDID did.DID, sourceID id.SourceID) error {
+func (r *Repo) AddSourceToSpace(ctx context.Context, spaceDID did.DID, sourceID id.SourceID) error {
 	_, err := r.db.ExecContext(ctx,
 		`INSERT INTO space_sources (space_did, source_id) VALUES (?, ?)`,
 		util.DbDID(&spaceDID), sourceID,
@@ -165,7 +165,7 @@ func (r *repo) AddSourceToSpace(ctx context.Context, spaceDID did.DID, sourceID 
 }
 
 // RemoveSourceFromSpace removes a source from a space in the repository.
-func (r *repo) RemoveSourceFromSpace(ctx context.Context, spaceDID did.DID, sourceID id.SourceID) error {
+func (r *Repo) RemoveSourceFromSpace(ctx context.Context, spaceDID did.DID, sourceID id.SourceID) error {
 	_, err := r.db.ExecContext(ctx,
 		`DELETE FROM space_sources WHERE space_did = ? AND source_id = ?`,
 		util.DbDID(&spaceDID), sourceID,

--- a/pkg/preparation/sqlrepo/sqlrepo.go
+++ b/pkg/preparation/sqlrepo/sqlrepo.go
@@ -27,10 +27,10 @@ func Null[T any](v *T) sql.Null[T] {
 }
 
 // New creates a new Repo instance with the given database connection.
-func New(db *sql.DB) *repo {
-	return &repo{db: db}
+func New(db *sql.DB) *Repo {
+	return &Repo{db: db}
 }
 
-type repo struct {
+type Repo struct {
 	db *sql.DB
 }

--- a/pkg/preparation/uploads/uploads.go
+++ b/pkg/preparation/uploads/uploads.go
@@ -23,6 +23,7 @@ type AddNodeToUploadShardsFunc func(ctx context.Context, uploadID id.UploadID, n
 type CloseUploadShardsFunc func(ctx context.Context, uploadID id.UploadID) (bool, error)
 type SpaceBlobAddShardsForUploadFunc func(ctx context.Context, uploadID id.UploadID) error
 type AddIndexesForUploadFunc func(ctx context.Context, uploadID id.UploadID) error
+type AddStorachaUploadForUploadFunc func(ctx context.Context, uploadID id.UploadID) error
 
 type API struct {
 	Repo                        Repo
@@ -30,6 +31,7 @@ type API struct {
 	ExecuteDagScansForUpload    ExecuteDagScansForUploadFunc
 	SpaceBlobAddShardsForUpload SpaceBlobAddShardsForUploadFunc
 	AddIndexesForUpload         AddIndexesForUploadFunc
+	AddStorachaUploadForUpload  AddStorachaUploadForUploadFunc
 
 	// AddNodeToUploadShards adds a node to the upload's shards, creating a new
 	// shard if necessary. It returns true if an existing open shard was closed,
@@ -307,6 +309,11 @@ func (e *executor) runStorachaWorker(ctx context.Context, blobWork <-chan struct
 			err := e.api.AddIndexesForUpload(ctx, e.upload.ID())
 			if err != nil {
 				return fmt.Errorf("`space/blob/add`ing index for upload %s: %w", e.upload.ID(), err)
+			}
+
+			err = e.api.AddStorachaUploadForUpload(ctx, e.upload.ID())
+			if err != nil {
+				return fmt.Errorf("`upload/add`ing upload %s: %w", e.upload.ID(), err)
 			}
 
 			return nil


### PR DESCRIPTION
Does the final `upload/add` invocation at the end of the upload process.







#### PR Dependency Tree


* **PR #118** 👈
  * **PR #124**
    * **PR #125**
      * **PR #126**
        * **PR #127**
          * **PR #128**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)