### PR TITLE
Add Configuration File Support

### DIFF
--- a/guppy.go
+++ b/guppy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/result"
 	"github.com/storacha/guppy/internal/cmdutil"
+	"github.com/storacha/guppy/internal/config"
 	"github.com/storacha/guppy/internal/upload"
 	"github.com/storacha/guppy/pkg/didmailto"
 	"github.com/urfave/cli/v2"
@@ -22,6 +23,7 @@ import (
 var log = logging.Logger("guppy/main")
 
 var commands = []*cli.Command{
+	config.ConfigCommand(),
 	{
 		Name:   "whoami",
 		Usage:  "Print information about the current agent.",

--- a/internal/config/cmd.go
+++ b/internal/config/cmd.go
@@ -1,0 +1,217 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+// ConfigCommand returns the configuration management command
+func ConfigCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "config",
+		Usage: "Manage guppy configuration",
+		Subcommands: []*cli.Command{
+			{
+				Name:   "init",
+				Usage:  "Initialize configuration file",
+				Action: initConfig,
+			},
+			{
+				Name:      "set",
+				Usage:     "Set a configuration value",
+				ArgsUsage: "<key> <value>",
+				Action:    setConfig,
+			},
+			{
+				Name:      "get",
+				Usage:     "Get a configuration value",
+				ArgsUsage: "<key>",
+				Action:    getConfig,
+			},
+			{
+				Name:   "list",
+				Usage:  "List all configuration values",
+				Action: listConfig,
+			},
+			{
+				Name:   "profile",
+				Usage:  "Manage configuration profiles",
+				Subcommands: []*cli.Command{
+					{
+						Name:      "create",
+						Usage:     "Create a new profile",
+						ArgsUsage: "<name>",
+						Action:    createProfile,
+					},
+					{
+						Name:      "delete",
+						Usage:     "Delete a profile",
+						ArgsUsage: "<name>",
+						Action:    deleteProfile,
+					},
+					{
+						Name:   "list",
+						Usage:  "List all profiles",
+						Action: listProfiles,
+					},
+				},
+			},
+		},
+	}
+}
+
+func initConfig(cCtx *cli.Context) error {
+	_, err := createDefaultConfig()
+	if err != nil {
+		return fmt.Errorf("failed to initialize config: %w", err)
+	}
+	fmt.Println("Configuration file initialized successfully")
+	return nil
+}
+
+func setConfig(cCtx *cli.Context) error {
+	if cCtx.NArg() != 2 {
+		return fmt.Errorf("expected key and value arguments")
+	}
+
+	key := cCtx.Args().Get(0)
+	value := cCtx.Args().Get(1)
+
+	mgr, err := NewManager()
+	if err != nil {
+		return err
+	}
+
+	if err := mgr.SetValue(key, value); err != nil {
+		return err
+	}
+
+	if err := mgr.Save(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Set %s = %s\n", key, value)
+	return nil
+}
+
+func getConfig(cCtx *cli.Context) error {
+	if cCtx.NArg() != 1 {
+		return fmt.Errorf("expected key argument")
+	}
+
+	key := cCtx.Args().First()
+
+	mgr, err := NewManager()
+	if err != nil {
+		return err
+	}
+
+	value, err := mgr.GetValue(key)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%v\n", value)
+	return nil
+}
+
+func listConfig(cCtx *cli.Context) error {
+	mgr, err := NewManager()
+	if err != nil {
+		return err
+	}
+
+	cfg := mgr.Get()
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	fmt.Println(string(data))
+	return nil
+}
+
+func createProfile(cCtx *cli.Context) error {
+	if cCtx.NArg() != 1 {
+		return fmt.Errorf("expected profile name argument")
+	}
+
+	name := cCtx.Args().First()
+
+	mgr, err := NewManager()
+	if err != nil {
+		return err
+	}
+
+	if mgr.config.Profiles == nil {
+		mgr.config.Profiles = make(map[string]*Profile)
+	}
+
+	if _, exists := mgr.config.Profiles[name]; exists {
+		return fmt.Errorf("profile %s already exists", name)
+	}
+
+	mgr.config.Profiles[name] = &Profile{
+		Verbose:         false,
+		JSONOutput:      false,
+		WrapSingleFiles: true,
+	}
+
+	if err := mgr.Save(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Created profile %s\n", name)
+	return nil
+}
+
+func deleteProfile(cCtx *cli.Context) error {
+	if cCtx.NArg() != 1 {
+		return fmt.Errorf("expected profile name argument")
+	}
+
+	name := cCtx.Args().First()
+
+	mgr, err := NewManager()
+	if err != nil {
+		return err
+	}
+
+	if _, exists := mgr.config.Profiles[name]; !exists {
+		return fmt.Errorf("profile %s does not exist", name)
+	}
+
+	delete(mgr.config.Profiles, name)
+
+	if err := mgr.Save(); err != nil {
+		return err
+	}
+
+	fmt.Printf("Deleted profile %s\n", name)
+	return nil
+}
+
+func listProfiles(cCtx *cli.Context) error {
+	mgr, err := NewManager()
+	if err != nil {
+		return err
+	}
+
+	if len(mgr.config.Profiles) == 0 {
+		fmt.Println("No profiles configured")
+		return nil
+	}
+
+	for name, profile := range mgr.config.Profiles {
+		fmt.Printf("Profile: %s\n", name)
+		data, err := yaml.Marshal(profile)
+		if err != nil {
+			return fmt.Errorf("failed to marshal profile: %w", err)
+		}
+		fmt.Printf("%s\n", strings.ReplaceAll(string(data), "\n", "\n  "))
+	}
+
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the root configuration structure
+type Config struct {
+	Default *DefaultConfig       `yaml:"default"`
+	Spaces  map[string]*Space   `yaml:"spaces"`
+	Upload  *UploadConfig       `yaml:"upload"`
+	Profiles map[string]*Profile `yaml:"profiles"`
+}
+
+// DefaultConfig holds the default settings
+type DefaultConfig struct {
+	Space      string `yaml:"space"`
+	ProofPath  string `yaml:"proof_path"`
+	JSONOutput bool   `yaml:"json_output"`
+	Verbose    bool   `yaml:"verbose"`
+}
+
+// Space represents a space configuration
+type Space struct {
+	DID       string `yaml:"did"`
+	ProofPath string `yaml:"proof_path"`
+}
+
+// UploadConfig holds upload-specific settings
+type UploadConfig struct {
+	DefaultShardSize  int64 `yaml:"default_shard_size"`
+	WrapSingleFiles   bool  `yaml:"wrap_single_files"`
+	IncludeHidden     bool  `yaml:"include_hidden"`
+}
+
+// Profile represents a named set of settings
+type Profile struct {
+	Space         string `yaml:"space"`
+	Verbose       bool   `yaml:"verbose"`
+	JSONOutput    bool   `yaml:"json_output"`
+	WrapSingleFiles bool `yaml:"wrap_single_files"`
+}
+
+// Manager handles configuration loading and saving
+type Manager struct {
+	config     *Config
+	configPath string
+}
+
+// DefaultConfig provides default configuration values
+func defaultConfig() *Config {
+	return &Config{
+		Default: &DefaultConfig{
+			JSONOutput: false,
+			Verbose:    false,
+		},
+		Spaces:   make(map[string]*Space),
+		Upload: &UploadConfig{
+			DefaultShardSize: 1073741824, // 1GB
+			WrapSingleFiles:  true,
+			IncludeHidden:    false,
+		},
+		Profiles: make(map[string]*Profile),
+	}
+}
+
+// NewManager creates a new configuration manager
+func NewManager() (*Manager, error) {
+	configPath, err := findConfigFile()
+	if err != nil {
+		// If no config file exists, create one with defaults
+		configPath, err = createDefaultConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create default config: %w", err)
+		}
+	}
+
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Manager{
+		config:     cfg,
+		configPath: configPath,
+	}, nil
+}
+
+// findConfigFile looks for a config file in standard locations
+func findConfigFile() (string, error) {
+	// Check current directory
+	if _, err := os.Stat(".guppy.yaml"); err == nil {
+		return ".guppy.yaml", nil
+	}
+
+	// Check user's home directory
+	home, err := os.UserHomeDir()
+	if err == nil {
+		path := filepath.Join(home, ".guppy", "config.yaml")
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+
+	// Check system-wide location
+	if _, err := os.Stat("/etc/guppy/config.yaml"); err == nil {
+		return "/etc/guppy/config.yaml", nil
+	}
+
+	return "", fmt.Errorf("no config file found")
+}
+
+// createDefaultConfig creates a default configuration file
+func createDefaultConfig() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	configDir := filepath.Join(home, ".guppy")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	configPath := filepath.Join(configDir, "config.yaml")
+	cfg := defaultConfig()
+
+	if err := saveConfig(configPath, cfg); err != nil {
+		return "", fmt.Errorf("failed to save default config: %w", err)
+	}
+
+	return configPath, nil
+}
+
+// loadConfig loads the configuration from a file
+func loadConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	cfg := defaultConfig()
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// saveConfig saves the configuration to a file
+func saveConfig(path string, cfg *Config) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
+}
+
+// Get returns the current configuration
+func (m *Manager) Get() *Config {
+	return m.config
+}
+
+// Save saves the current configuration
+func (m *Manager) Save() error {
+	return saveConfig(m.configPath, m.config)
+}
+
+// SetValue sets a configuration value by path
+func (m *Manager) SetValue(path string, value interface{}) error {
+	return fmt.Errorf("not implemented")
+}
+
+// GetValue gets a configuration value by path
+func (m *Manager) GetValue(path string) (interface{}, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigManager(t *testing.T) {
+	// Create a temporary directory for test config files
+	tmpDir, err := os.MkdirTemp("", "guppy-config-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Set up a test config file
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	testConfig := &Config{
+		Default: &DefaultConfig{
+			Space:      "test-space",
+			ProofPath:  "/test/path",
+			JSONOutput: true,
+			Verbose:    true,
+		},
+		Spaces: map[string]*Space{
+			"test": {
+				DID:       "did:test:123",
+				ProofPath: "/test/proofs",
+			},
+		},
+		Upload: &UploadConfig{
+			DefaultShardSize: 1024,
+			WrapSingleFiles: true,
+			IncludeHidden:   false,
+		},
+		Profiles: map[string]*Profile{
+			"test": {
+				Space:      "test",
+				Verbose:    true,
+				JSONOutput: true,
+			},
+		},
+	}
+
+	// Save test config
+	err = saveConfig(configPath, testConfig)
+	require.NoError(t, err)
+
+	// Test loading config
+	loadedConfig, err := loadConfig(configPath)
+	require.NoError(t, err)
+
+	// Verify loaded config matches test config
+	assert.Equal(t, testConfig.Default.Space, loadedConfig.Default.Space)
+	assert.Equal(t, testConfig.Default.ProofPath, loadedConfig.Default.ProofPath)
+	assert.Equal(t, testConfig.Default.JSONOutput, loadedConfig.Default.JSONOutput)
+	assert.Equal(t, testConfig.Default.Verbose, loadedConfig.Default.Verbose)
+
+	assert.Equal(t, testConfig.Spaces["test"].DID, loadedConfig.Spaces["test"].DID)
+	assert.Equal(t, testConfig.Spaces["test"].ProofPath, loadedConfig.Spaces["test"].ProofPath)
+
+	assert.Equal(t, testConfig.Upload.DefaultShardSize, loadedConfig.Upload.DefaultShardSize)
+	assert.Equal(t, testConfig.Upload.WrapSingleFiles, loadedConfig.Upload.WrapSingleFiles)
+	assert.Equal(t, testConfig.Upload.IncludeHidden, loadedConfig.Upload.IncludeHidden)
+
+	assert.Equal(t, testConfig.Profiles["test"].Space, loadedConfig.Profiles["test"].Space)
+	assert.Equal(t, testConfig.Profiles["test"].Verbose, loadedConfig.Profiles["test"].Verbose)
+	assert.Equal(t, testConfig.Profiles["test"].JSONOutput, loadedConfig.Profiles["test"].JSONOutput)
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := defaultConfig()
+
+	assert.NotNil(t, cfg.Default)
+	assert.NotNil(t, cfg.Spaces)
+	assert.NotNil(t, cfg.Upload)
+	assert.NotNil(t, cfg.Profiles)
+
+	assert.False(t, cfg.Default.JSONOutput)
+	assert.False(t, cfg.Default.Verbose)
+
+	assert.Equal(t, int64(1073741824), cfg.Upload.DefaultShardSize)
+	assert.True(t, cfg.Upload.WrapSingleFiles)
+	assert.False(t, cfg.Upload.IncludeHidden)
+}
+
+func TestConfigFileCreation(t *testing.T) {
+	// Create a temporary directory for test
+	tmpDir, err := os.MkdirTemp("", "guppy-config-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Set home directory to temp directory for test
+	originalHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", originalHome)
+
+	// Test creating default config
+	configPath, err := createDefaultConfig()
+	require.NoError(t, err)
+
+	// Verify config file exists
+	_, err = os.Stat(configPath)
+	assert.NoError(t, err)
+
+	// Verify config file contains valid YAML
+	cfg, err := loadConfig(configPath)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+}


### PR DESCRIPTION
Fixes #120 

PR introduces configuration file support for Guppy, making it easier for users to avoid typing the same flags over and over again. With this change, users can define defaults, manage environment-specific settings, and create custom profiles directly in a config file.


