### PR TITLE
feat: extract receipt from `ucan/conclude` invocation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/multiformats/go-varint v0.1.0
 	github.com/spf13/afero v1.6.0
 	github.com/storacha/go-libstoracha v0.2.8
-	github.com/storacha/go-ucanto v0.6.7-0.20251031130612-a2d468774250
+	github.com/storacha/go-ucanto v0.6.7
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.25.7 // indirect
 	golang.org/x/sync v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -550,10 +550,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/storacha/go-libstoracha v0.2.8 h1:vQ+kCnRruzAekAiW4nJ0JnQrH4NbareSEydX+Laviv0=
 github.com/storacha/go-libstoracha v0.2.8/go.mod h1:zzeqIZhBBuWR2dkGygYqv4Bhg3JsvHuuvDCcdXCwGhg=
-github.com/storacha/go-ucanto v0.6.2 h1:4049ZUXGsdwdu9+FU6CssMDmpxQJbHTf6+EwEinaXmU=
-github.com/storacha/go-ucanto v0.6.2/go.mod h1:O35Ze4x18EWtz3ftRXXd/mTZ+b8OQVjYYrnadJ/xNjg=
-github.com/storacha/go-ucanto v0.6.7-0.20251031130612-a2d468774250 h1:4mjzLGzgn0o3E8k0W1EUKmfzhn3WefQqzN+H45gLcoc=
-github.com/storacha/go-ucanto v0.6.7-0.20251031130612-a2d468774250/go.mod h1:O35Ze4x18EWtz3ftRXXd/mTZ+b8OQVjYYrnadJ/xNjg=
+github.com/storacha/go-ucanto v0.6.7 h1:rKNCyt9n4FwzCXIb+FDQ2Lcic+yNQK10PkGi4VipoM0=
+github.com/storacha/go-ucanto v0.6.7/go.mod h1:O35Ze4x18EWtz3ftRXXd/mTZ+b8OQVjYYrnadJ/xNjg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/pkg/receipt/client_test.go
+++ b/pkg/receipt/client_test.go
@@ -63,7 +63,7 @@ func TestFetch(t *testing.T) {
 		require.Equal(t, inv.Link(), result.Ran().Link())
 	})
 
-	t.Run("found in ucan/conclude", func(t *testing.T) {
+	t.Run("found in ucan/conclude invocation", func(t *testing.T) {
 		inv, err := invocation.Invoke(
 			testutil.Alice,
 			testutil.Service,
@@ -100,6 +100,67 @@ func TestFetch(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			msg, err := message.Build([]invocation.Invocation{ccInv}, nil)
+			require.NoError(t, err)
+			res, err := response.Encode(msg)
+			require.NoError(t, err)
+			_, err = io.Copy(w, res.Body())
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		endpoint, err := url.Parse(server.URL)
+		require.NoError(t, err)
+
+		client := receiptclient.New(endpoint)
+		result, err := client.Fetch(t.Context(), inv.Link())
+		require.NoError(t, err)
+		require.Equal(t, inv.Link(), result.Ran().Link())
+	})
+
+	t.Run("found in ucan/conclude receipt", func(t *testing.T) {
+		inv, err := invocation.Invoke(
+			testutil.Alice,
+			testutil.Service,
+			ucan.NewCapability(
+				"test/receipt",
+				testutil.Alice.DID().String(),
+				ucan.NoCaveats{},
+			),
+		)
+		require.NoError(t, err)
+
+		rcpt, err := receipt.Issue(
+			testutil.Alice,
+			result.Ok[ok.Unit, failure.IPLDBuilderFailure](ok.Unit{}),
+			ran.FromInvocation(inv),
+		)
+		require.NoError(t, err)
+
+		ccInv, err := ucancap.Conclude.Invoke(
+			testutil.Alice,
+			testutil.Service,
+			testutil.Alice.DID().String(),
+			ucancap.ConcludeCaveats{
+				Receipt: rcpt.Root().Link(),
+			},
+		)
+		require.NoError(t, err)
+
+		// attach the receipt to the conclude invocation
+		for b, err := range rcpt.Blocks() {
+			require.NoError(t, err)
+			require.NoError(t, ccInv.Attach(b))
+		}
+
+		ccRcpt, err := receipt.Issue(
+			testutil.Service,
+			result.Ok[ok.Unit, failure.IPLDBuilderFailure](ok.Unit{}),
+			ran.FromInvocation(ccInv),
+		)
+		require.NoError(t, err)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			msg, err := message.Build(nil, []receipt.AnyReceipt{ccRcpt})
 			require.NoError(t, err)
 			res, err := response.Encode(msg)
 			require.NoError(t, err)


### PR DESCRIPTION
The receipts endpoint returns an agent message that contains the receipt. However the agent message may have been a `ucan/conclude` invocation with the receipt attached.

This PR enables the receipts client to extract the receipt from the agent message in this case.

Port of https://github.com/storacha/upload-service/blob/e41f9293fe25927ace7a69522d1a5593aa61603c/packages/upload-client/src/receipts.js#L138-L167