### PR TITLE
feat(storacha): add pdp/accept to filecoin/offer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/multiformats/go-varint v0.1.0
 	github.com/spf13/afero v1.12.0
-	github.com/storacha/go-libstoracha v0.4.0
+	github.com/storacha/go-libstoracha v0.4.1-0.20251112231023-e91d94d244f2
 	github.com/storacha/go-ucanto v0.6.7
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.25.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -561,8 +561,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
-github.com/storacha/go-libstoracha v0.4.0 h1:QkJKOE4zQ13p478tMr6C5pY3VHQxqaBE8kGDiY3TqTQ=
-github.com/storacha/go-libstoracha v0.4.0/go.mod h1:PLTFCREzKlZMY9cuZDCJUh2DiCWLKQEyTQhYM1muy9M=
+github.com/storacha/go-libstoracha v0.4.1-0.20251112231023-e91d94d244f2 h1:W3ZS5C+4gbk4710B/RFFcpisnepAGuJW0rQByzWLD7U=
+github.com/storacha/go-libstoracha v0.4.1-0.20251112231023-e91d94d244f2/go.mod h1:PLTFCREzKlZMY9cuZDCJUh2DiCWLKQEyTQhYM1muy9M=
 github.com/storacha/go-ucanto v0.6.7 h1:rKNCyt9n4FwzCXIb+FDQ2Lcic+yNQK10PkGi4VipoM0=
 github.com/storacha/go-ucanto v0.6.7/go.mod h1:O35Ze4x18EWtz3ftRXXd/mTZ+b8OQVjYYrnadJ/xNjg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/client/filecoinoffer.go
+++ b/pkg/client/filecoinoffer.go
@@ -5,27 +5,79 @@ import (
 	"fmt"
 
 	filecoincap "github.com/storacha/go-libstoracha/capabilities/filecoin"
+	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/ipld"
 	"github.com/storacha/go-ucanto/core/result"
 	"github.com/storacha/go-ucanto/did"
 )
 
-func (c *Client) FilecoinOffer(ctx context.Context, space did.DID, content ipld.Link, piece ipld.Link) (filecoincap.OfferOk, error) {
+type FilecoinOfferOptions struct {
+	pdpAcceptInvocation invocation.Invocation
+}
+
+func (foo *FilecoinOfferOptions) PDPAcceptInvocation() invocation.Invocation {
+	return foo.pdpAcceptInvocation
+}
+
+type FilecoinOfferOption func(opts *FilecoinOfferOptions)
+
+func WithPDPAcceptInvocation(inv invocation.Invocation) FilecoinOfferOption {
+	return func(opts *FilecoinOfferOptions) {
+		opts.pdpAcceptInvocation = inv
+	}
+}
+
+func NewFilecoinOfferOptions(opts []FilecoinOfferOption) *FilecoinOfferOptions {
+	config := &FilecoinOfferOptions{}
+	for _, o := range opts {
+		o(config)
+	}
+	return config
+}
+
+func (c *Client) FilecoinOffer(ctx context.Context, space did.DID, content ipld.Link, piece ipld.Link, opts ...FilecoinOfferOption) (filecoincap.OfferOk, error) {
+	config := NewFilecoinOfferOptions(opts)
+
 	caveats := filecoincap.OfferCaveats{
 		Content: content,
 		Piece:   piece,
 	}
 
-	res, _, err := invokeAndExecute[filecoincap.OfferCaveats, filecoincap.OfferOk](
-		ctx,
+	if config.pdpAcceptInvocation != nil {
+		pdpAcceptLink := config.pdpAcceptInvocation.Link()
+		caveats.PDP = &pdpAcceptLink
+	}
+	inv, err := invoke[filecoincap.OfferCaveats, filecoincap.OfferOk](
 		c,
 		filecoincap.Offer,
 		space.String(),
 		caveats,
+	)
+	if err != nil {
+		return filecoincap.OfferOk{}, fmt.Errorf("invoking `filecoin/offer`: %w", err)
+	}
+
+	if config.pdpAcceptInvocation != nil {
+		for b, err := range config.pdpAcceptInvocation.Export() {
+			if err != nil {
+				return filecoincap.OfferOk{}, fmt.Errorf("getting block from pdp offer invocation: %w", err)
+			}
+			err = inv.Attach(b)
+			if err != nil {
+				return filecoincap.OfferOk{}, fmt.Errorf("attaching pdp offer invocation block to filecoin offer invocation: %w", err)
+			}
+		}
+	}
+
+	res, _, err := execute[filecoincap.OfferCaveats, filecoincap.OfferOk](
+		ctx,
+		c,
+		filecoincap.Offer,
+		inv,
 		filecoincap.OfferOkType(),
 	)
 	if err != nil {
-		return filecoincap.OfferOk{}, fmt.Errorf("invoking and executing `filecoin/offer`: %w", err)
+		return filecoincap.OfferOk{}, fmt.Errorf("executing `filecoin/offer`: %w", err)
 	}
 
 	offerOk, failErr := result.Unwrap(res)

--- a/pkg/client/filecoinoffer_test.go
+++ b/pkg/client/filecoinoffer_test.go
@@ -10,6 +10,8 @@ import (
 	commp "github.com/filecoin-project/go-fil-commp-hashhash"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	filecoincap "github.com/storacha/go-libstoracha/capabilities/filecoin"
+	pdpcap "github.com/storacha/go-libstoracha/capabilities/pdp"
+	"github.com/storacha/go-ucanto/core/dag/blockstore"
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/receipt/fx"
@@ -25,44 +27,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type recordedInvocation struct {
+	capability ucan.Capability[filecoincap.OfferCaveats]
+	invocation invocation.Invocation
+}
+
 func TestFilecoinOffer(t *testing.T) {
 	space, err := ed25519signer.Generate()
 	require.NoError(t, err)
 
-	invokedCapabilities := []ucan.Capability[filecoincap.OfferCaveats]{}
-
-	connection := testutil.NewTestServerConnection(
-		server.WithServiceMethod(
-			filecoincap.Offer.Can(),
-			server.Provide(
-				filecoincap.Offer,
-				func(
-					ctx context.Context,
-					cap ucan.Capability[filecoincap.OfferCaveats],
-					inv invocation.Invocation,
-					context server.InvocationContext,
-				) (result.Result[filecoincap.OfferOk, failure.IPLDBuilderFailure], fx.Effects, error) {
-					invokedCapabilities = append(invokedCapabilities, cap)
-					return result.Ok[filecoincap.OfferOk, failure.IPLDBuilderFailure](
-						filecoincap.OfferOk{
-							Piece: cap.Nb().Piece,
-						},
-					), nil, nil
-				},
-			),
-		),
-	)
-
-	c := uhelpers.Must(client.NewClient(client.WithConnection(connection)))
-
-	// Delegate * on the space to the client
-	cap := ucan.NewCapability("*", space.DID().String(), ucan.NoCaveats{})
-	proof, err := delegation.Delegate(space, c.Issuer(), []ucan.Capability[ucan.NoCaveats]{cap}, delegation.WithNoExpiration())
-	require.NoError(t, err)
-	err = c.AddProofs(proof)
-	require.NoError(t, err)
-
 	blobLink := helpers.RandomCID()
+
+	dummyPrincipal, err := ed25519signer.Generate()
+	require.NoError(t, err)
+
+	pdpAcceptInv, err := pdpcap.Accept.Invoke(
+		dummyPrincipal,
+		dummyPrincipal.DID(),
+		space.DID().String(),
+		pdpcap.AcceptCaveats{
+			Blob: blobLink.(cidlink.Link).Cid.Hash(),
+		},
+	)
+	require.NoError(t, err)
 
 	cp := &commp.Calc{}
 	_, err = io.CopyN(cp, crand.Reader, 128)
@@ -73,14 +60,89 @@ func TestFilecoinOffer(t *testing.T) {
 	require.NoError(t, err)
 	blobPieceLink := cidlink.Link{Cid: blobPieceCID}
 
-	offerOk, err := c.FilecoinOffer(t.Context(), space.DID(), blobLink, blobPieceLink)
-	require.NoError(t, err)
+	testCases := []struct {
+		name           string
+		opts           []client.FilecoinOfferOption
+		testCapability func(t *testing.T, rc recordedInvocation, offerOk filecoincap.OfferOk)
+	}{
+		{
+			name: "without PDP offer invocation",
+			opts: nil,
+			testCapability: func(t *testing.T, rc recordedInvocation, offerOk filecoincap.OfferOk) {
+				capability := rc.capability
+				require.Equal(t, space.DID().String(), capability.With(), "expected to have the space as the resource")
+				require.Equal(t, blobLink, capability.Nb().Content, "expected to have the correct content link")
+				require.Equal(t, blobPieceLink, capability.Nb().Piece, "expected to have the correct piece link")
+				require.Equal(t, blobPieceLink, offerOk.Piece, "expected to get the correct piece link in the response")
+			},
+		},
+		{
+			name: "with PDP offer invocation",
+			opts: []client.FilecoinOfferOption{
+				client.WithPDPAcceptInvocation(pdpAcceptInv),
+			},
+			testCapability: func(t *testing.T, rc recordedInvocation, offerOk filecoincap.OfferOk) {
+				capability := rc.capability
+				require.Equal(t, space.DID().String(), capability.With(), "expected to have the space as the resource")
+				require.Equal(t, blobLink, capability.Nb().Content, "expected to have the correct content link")
+				require.Equal(t, blobPieceLink, capability.Nb().Piece, "expected to have the correct piece link")
+				require.Equal(t, blobPieceLink, offerOk.Piece, "expected to get the correct piece link in the response")
+				require.Equal(t, *capability.Nb().PDP, pdpAcceptInv.Link(), "expected to have the PDP accept invocation link in the capability")
+				bs := uhelpers.Must(blockstore.NewBlockReader(blockstore.WithBlocksIterator(rc.invocation.Blocks())))
+				del, err := delegation.NewDelegationView(pdpAcceptInv.Link(), bs)
+				require.NoError(t, err)
+				require.Len(t, del.Capabilities(), 1, "expected the PDP accept delegation to have exactly one capability")
+				require.Equal(t, del.Capabilities()[0].With(), space.DID().String(), "expected the PDP accept delegation to have the space as the resource")
+				require.Equal(t, del.Capabilities()[0].Can(), pdpcap.AcceptAbility)
+			},
+		},
+	}
 
-	require.Len(t, invokedCapabilities, 1, "expected exactly one capability to be invoked")
-	capability := invokedCapabilities[0]
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			invokedCapabilities := []recordedInvocation{}
 
-	require.Equal(t, space.DID().String(), capability.With(), "expected to have the space as the resource")
-	require.Equal(t, blobLink, capability.Nb().Content, "expected to have the correct content link")
-	require.Equal(t, blobPieceLink, capability.Nb().Piece, "expected to have the correct piece link")
-	require.Equal(t, blobPieceLink, offerOk.Piece, "expected to get the correct piece link in the response")
+			connection := testutil.NewTestServerConnection(
+				server.WithServiceMethod(
+					filecoincap.Offer.Can(),
+					server.Provide(
+						filecoincap.Offer,
+						func(
+							ctx context.Context,
+							cap ucan.Capability[filecoincap.OfferCaveats],
+							inv invocation.Invocation,
+							context server.InvocationContext,
+						) (result.Result[filecoincap.OfferOk, failure.IPLDBuilderFailure], fx.Effects, error) {
+							invokedCapabilities = append(invokedCapabilities, recordedInvocation{
+								capability: cap,
+								invocation: inv,
+							})
+							return result.Ok[filecoincap.OfferOk, failure.IPLDBuilderFailure](
+								filecoincap.OfferOk{
+									Piece: cap.Nb().Piece,
+								},
+							), nil, nil
+						},
+					),
+				),
+			)
+
+			c := uhelpers.Must(client.NewClient(client.WithConnection(connection)))
+
+			// Delegate * on the space to the client
+			cap := ucan.NewCapability("*", space.DID().String(), ucan.NoCaveats{})
+			proof, err := delegation.Delegate(space, c.Issuer(), []ucan.Capability[ucan.NoCaveats]{cap}, delegation.WithNoExpiration())
+			require.NoError(t, err)
+			err = c.AddProofs(proof)
+			require.NoError(t, err)
+
+			offerOk, err := c.FilecoinOffer(t.Context(), space.DID(), blobLink, blobPieceLink, tc.opts...)
+			require.NoError(t, err)
+
+			require.Len(t, invokedCapabilities, 1, "expected exactly one capability to be invoked")
+			capability := invokedCapabilities[0]
+
+			tc.testCapability(t, capability, offerOk)
+		})
+	}
 }

--- a/pkg/client/spaceblobadd_test.go
+++ b/pkg/client/spaceblobadd_test.go
@@ -31,13 +31,13 @@ func TestSpaceBlobAdd(t *testing.T) {
 
 	testBlob := bytes.NewReader([]byte("test"))
 
-	returnedDigest, _, err := c.SpaceBlobAdd(testContext(t), testBlob, space.DID(), client.WithPutClient(putClient))
+	addedBlob, err := c.SpaceBlobAdd(testContext(t), testBlob, space.DID(), client.WithPutClient(putClient))
 	require.NoError(t, err)
 
 	digest, err := multihash.Sum([]byte("test"), multihash.SHA2_256, -1)
 	require.NoError(t, err)
 
-	require.Equal(t, digest, returnedDigest)
+	require.Equal(t, digest, addedBlob.Multihash)
 	require.Equal(t, []byte("test"), testutil.ReceivedBlobs(putClient).Get(digest))
 	require.Equal(t, 1, testutil.ReceivedBlobs(putClient).Size())
 }

--- a/pkg/client/testutil/client.go
+++ b/pkg/client/testutil/client.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/multiformats/go-multihash"
-	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/server"
 	"github.com/storacha/guppy/pkg/client"
@@ -66,6 +64,6 @@ type ClientWithCustomPut struct {
 
 var _ storacha.Client = (*ClientWithCustomPut)(nil)
 
-func (c *ClientWithCustomPut) SpaceBlobAdd(ctx context.Context, content io.Reader, space did.DID, options ...client.SpaceBlobAddOption) (multihash.Multihash, delegation.Delegation, error) {
+func (c *ClientWithCustomPut) SpaceBlobAdd(ctx context.Context, content io.Reader, space did.DID, options ...client.SpaceBlobAddOption) (client.AddedBlob, error) {
 	return c.Client.SpaceBlobAdd(ctx, content, space, append(options, client.WithPutClient(c.PutClient))...)
 }

--- a/pkg/preparation/storacha/storacha_test.go
+++ b/pkg/preparation/storacha/storacha_test.go
@@ -131,6 +131,7 @@ func TestAddShardsForUpload(t *testing.T) {
 		shardPieceLink := cidlink.Link{Cid: shardPieceCID}
 
 		require.Equal(t, shardPieceLink, client.FilecoinOfferInvocations[0].Piece)
+		require.Equal(t, *client.SpaceBlobAddInvocations[0].ReturnedPDPAccept, client.FilecoinOfferInvocations[0].Options.PDPAcceptInvocation())
 
 		// Now close the upload shards and run it again.
 		_, err = shardsApi.CloseUploadShards(t.Context(), upload.ID())


### PR DESCRIPTION
# Goals

Enable the upload service to reconcile pieces via pdp/info when doing filecoin/offer

# Implementation

- use newest go-libstoracha
- modify client.SpaceBlobAdd to return AddedBlob
- extract and add PDPAcceptInvocation when present in client.SpaceBlobAdd
- add PDPAcceptInvocation as option on client.FilecoinOffer
- in storacha module for preparation, pass PDPAcceptInvocation from client.SpaceBlobAdd to client.FilecoinOffer