### PR TITLE
fix: ignore guppy bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 /last-upload-id.txt
 /*.gif
 /demo.db*
+guppy


### PR DESCRIPTION
Makefile builds binary and puts it in the project root. Add it to gitigore so we don't accidentally commit it.