### PR TITLE
fix: restore cursor when login is interrupted

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -49,8 +49,8 @@ var loginCmd = &cobra.Command{
 		s := spinner.New(spinner.CharSets[14], 100*time.Millisecond) // Spinner: ⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏
 		s.Suffix = fmt.Sprintf(" 🔗 please click the link sent to %s to authorize this agent", email)
 		s.Start()
+		defer s.Stop()
 		claimedDels, err := result.Unwrap(<-resultChan)
-		s.Stop()
 
 		if cmd.Context().Err() != nil {
 			return fmt.Errorf("login canceled: %w", cmd.Context().Err())

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/signal"
+	"syscall"
 
 	logging "github.com/ipfs/go-log/v2"
 
@@ -25,7 +27,8 @@ func main() {
 		}
 	}()
 
-	ctx := context.Background()
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
 
 	// Set up OpenTelemetry.
 	otelShutdown, err := setupOTelSDK(ctx)


### PR DESCRIPTION
Issue Fixed #185

This PR addresses an issue where interrupting guppy login with Ctrl+C would leave the terminal cursor hidden.

Summary of Changes

- main.go: Switched to signal.NotifyContext to properly catch SIGINT and SIGTERM. This gives the app a chance to shut down gracefully instead of exiting abruptly.

- cmd/login.go: Added defer s.Stop() so the spinner always stops and restores the cursor—regardless of whether the login succeeds, fails, or the context gets canceled.

Reasoning

Previously, the process terminated immediately on Ctrl+C, so the spinner cleanup code never ran. By handling signals through the context and ensuring the spinner is stopped in all code paths, we avoid leaving the terminal in a broken state.

Verification

- Tested locally by running guppy login and interrupting it multiple times.
- The command now exits cleanly with a context canceled message, and the cursor is consistently restored.
- Verified that interrupting other long-running commands (like guppy upload) also shuts down cleanly without errors or state corruption, confirming the global signal handling works as expected.