### PR TITLE
feat: Guppy source now support single file uploads, not just a directory and fix tiny file crash

### DIFF
--- a/pkg/preparation/singlefilefs.go
+++ b/pkg/preparation/singlefilefs.go
@@ -1,0 +1,17 @@
+package preparation
+import (
+	"io/fs"
+	"os"
+)
+// singleFileFS adapts a single file to the fs.FS interface.
+// The file is exposed as the root entry "." of the filesystem.
+type singleFileFS struct {
+	path string
+}
+
+func (s singleFileFS) Open(name string) (fs.File, error) {
+	if name == "." {
+		return os.Open(s.path)
+	}
+	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+}

--- a/pkg/preparation/singlefilefs_test.go
+++ b/pkg/preparation/singlefilefs_test.go
@@ -1,0 +1,29 @@
+package preparation
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSingleFileFS(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.txt")
+	err := os.WriteFile(tmpFile, []byte("content"), 0644)
+	require.NoError(t, err)
+	sfs := singleFileFS{path: tmpFile}
+
+	// Should be able to open root
+	f, err := sfs.Open(".")
+	require.NoError(t, err)
+	content, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, "content", string(content))
+	f.Close()
+
+	// Should reject other paths
+	_, err = sfs.Open("other")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+}

--- a/pkg/preparation/storacha/storacha.go
+++ b/pkg/preparation/storacha/storacha.go
@@ -172,10 +172,13 @@ func (a API) filecoinOffer(ctx context.Context, shard *shardsmodel.Shard, spaceD
 	ctx, span := tracer.Start(ctx, "filecoin-offer")
 	defer span.End()
 
-	// On shards too small to compute a CommP, just skip the `filecoin/offer`.
+	// Check against the official block size rather than the payload minimum
+	cp := &commp.Calc{}
+	minPieceSize := uint64(cp.BlockSize())
+
 	switch {
-	case shard.Size() < commp.MinPiecePayload:
-		log.Warnf("skipping `filecoin/offer` for shard %s: size %d is below minimum %d", shard.ID(), shard.Size(), commp.MinPiecePayload)
+	case shard.Size() < minPieceSize:
+		log.Warnf("skipping `filecoin/offer` for shard %s: size %d is below minimum %d", shard.ID(), shard.Size(), minPieceSize)
 		return nil
 	case shard.Size() > commp.MaxPiecePayload:
 		log.Warnf("skipping `filecoin/offer` for shard %s: size %d is above maximum %d", shard.ID(), shard.Size(), commp.MaxPiecePayload)


### PR DESCRIPTION
Issue Fixed #182

Description
I've updated the source handling so users can now add a single file as an upload source (e.g., guppy upload sources add <did> ./file.txt). Previously, this would fail with (stat .: not a directory) because the code was strictly using os.DirFS, which only supports directories.

While working on this, I also ran into an issue when uploading very small files (under 127 bytes) due to a mismatch with Filecoin Piece size constraints, so I included a fix for that as well.

Changes
- pkg/preparation/singlefilefs.go: Added a simple fs.FS adapter that treats a single file as the filesystem root ..
- pkg/preparation/preparation.go: Updated NewAPI to check the path with os.Stat. It now dynamically selects os.DirFS for directories or the new singleFileFS for files.
- pkg/preparation/storacha/storacha.go: Updated filecoinOffer to check against commp.BlockSize() (127 bytes) instead of the internal payload minimum. Shards smaller than this limit now gracefully skip the filecoin/offer step instead of causing a crash.
- Tests: Added TestSingleFileFS unit test and a TestExecuteUpload integration case to verify the end-to-end flow for single files.

Verification
- Verified locally by uploading single text files (tested both large files and tiny ones).
- Confirmed that tiny files (72 bytes) no longer crash the worker.
- Ran go test ./... to ensure no regressions.