### PR TITLE
fix: Interrupted `login` restores cursor

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -50,6 +53,22 @@ var loginCmd = &cobra.Command{
 		s := spinner.New(spinner.CharSets[14], 100*time.Millisecond) // Spinner: ⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏
 		s.Suffix = fmt.Sprintf(" 🔗 please click the link sent to %s to authorize this agent", email)
 		s.Start()
+
+		// Set up signal handling to ensure spinner stops on interrupt
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(sigChan)
+
+		go func() {
+			sig := <-sigChan
+			s.Stop()
+			// Exit with 128 + signal number (conventional for signal termination)
+			if s, ok := sig.(syscall.Signal); ok {
+				os.Exit(128 + int(s))
+			}
+			os.Exit(1)
+		}()
+
 		claimedDels, err := result.Unwrap(<-resultChan)
 		s.Stop()
 


### PR DESCRIPTION
Closes #185 

#### PR Dependency Tree


* **PR #175**
  * **PR #187**
    * **PR #198**
      * **PR #200** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)