### PR TITLE
feat(preparation): improve retriability

### DIFF
--- a/cmd/internal/upload/demo/demo.go
+++ b/cmd/internal/upload/demo/demo.go
@@ -356,5 +356,5 @@ func Demo(ctx context.Context, repo *sqlrepo.Repo, spaceName string, alterMetada
 
 	}
 
-	return ui.RunUploadUI(ctx, repo, api, uploads)
+	return ui.RunUploadUI(ctx, repo, api, uploads, false)
 }

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -20,6 +20,10 @@ import (
 var uploadDbPath string
 var storePath string
 
+var (
+	retry bool
+)
+
 var uploadCmd = &cobra.Command{
 	Use:     "upload <space>",
 	Aliases: []string{"up"},
@@ -67,7 +71,7 @@ var uploadCmd = &cobra.Command{
 			return cmdutil.NewHandledCliError(fmt.Errorf("no uploads found for space %s", spaceDID))
 		}
 
-		return ui.RunUploadUI(ctx, repo, api, uploads)
+		return ui.RunUploadUI(ctx, repo, api, uploads, retry)
 	},
 }
 
@@ -80,6 +84,7 @@ func init() {
 		filepath.Join(uploadDbPath, "preparation.db"),
 		"Path to the preparation database file (default: <storachaDir>/preparation.db)",
 	)
+	uploadCmd.Flags().BoolVar(&retry, "retry", false, "Auto-retry failed uploads")
 }
 
 var uploadSourcesCmd = &cobra.Command{

--- a/pkg/preparation/preparation.go
+++ b/pkg/preparation/preparation.go
@@ -133,6 +133,7 @@ func NewAPI(repo Repo, client StorachaClient, options ...Option) API {
 		AddStorachaUploadForUpload: storachaAPI.AddStorachaUploadForUpload,
 		RemoveBadFSEntry:           scansAPI.RemoveBadFSEntry,
 		RemoveBadNodes:             dagsAPI.RemoveBadNodes,
+		RemoveShard:                shardsAPI.RemoveShard,
 	}
 
 	return API{

--- a/pkg/preparation/repo.go
+++ b/pkg/preparation/repo.go
@@ -4,17 +4,35 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/storacha/guppy/pkg/preparation/sqlrepo"
 	_ "modernc.org/sqlite"
 )
 
+const (
+	defaultJournalMode = "WAL"
+	defaultSynchronous = "NORMAL"
+	defaultBusyTimeout = 3 * time.Second
+	defaultForeignKeys = true
+)
+
 func OpenRepo(ctx context.Context, dbPath string) (*sqlrepo.Repo, error) {
-	db, err := sql.Open("sqlite", dbPath)
+	var pragmas []string
+	pragmas = append(pragmas, fmt.Sprintf("_pragma=journal_mode(%s)", defaultJournalMode))
+	pragmas = append(pragmas, fmt.Sprintf("_pragma=busy_timeout(%d)", defaultBusyTimeout.Milliseconds()))
+	pragmas = append(pragmas, fmt.Sprintf("_pragma=synchronous(%s)", defaultSynchronous))
+	pragmas = append(pragmas, fmt.Sprintf("_pragma=foreign_keys(%d)", bool2int(defaultForeignKeys)))
+
+	connStr := fmt.Sprintf("file:%s?%s", dbPath, strings.Join(pragmas, "&"))
+	db, err := sql.Open("sqlite", connStr)
+
 	if err != nil {
 		return nil, fmt.Errorf("command failed to open SQLite database at %s: %w", dbPath, err)
 	}
 	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 
 	_, err = db.ExecContext(ctx, sqlrepo.Schema)
 	if err != nil {
@@ -23,4 +41,11 @@ func OpenRepo(ctx context.Context, dbPath string) (*sqlrepo.Repo, error) {
 
 	repo := sqlrepo.New(db)
 	return repo, nil
+}
+
+func bool2int(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }

--- a/pkg/preparation/shards/repo.go
+++ b/pkg/preparation/shards/repo.go
@@ -20,4 +20,5 @@ type Repo interface {
 	FindNodeByCIDAndSpaceDID(ctx context.Context, c cid.Cid, spaceDID did.DID) (dagsmodel.Node, error)
 	ForEachNode(ctx context.Context, shardID id.ShardID, yield func(node dagsmodel.Node, shardOffset uint64) error) error
 	GetSpaceByDID(ctx context.Context, spaceDID did.DID) (*spacesmodel.Space, error)
+	DeleteShard(ctx context.Context, shardID id.ShardID) error
 }

--- a/pkg/preparation/shards/shards.go
+++ b/pkg/preparation/shards/shards.go
@@ -213,14 +213,17 @@ func (a API) makeErrBadNodes(ctx context.Context, shardID id.ShardID) error {
 	}
 
 	var errs []types.ErrBadNode
+	goodCIDs := cid.NewSet()
 	for _, node := range nodes {
 		_, err := a.NodeReader.GetData(ctx, node)
 		if err != nil {
 			errs = append(errs, types.NewErrBadNode(node.CID(), err))
+		} else {
+			goodCIDs.Add(node.CID())
 		}
 	}
 
-	return types.NewErrBadNodes(errs)
+	return types.NewErrBadNodes(errs, shardID, goodCIDs)
 }
 
 func lengthVarint(size uint64) []byte {
@@ -333,4 +336,8 @@ func (a API) IndexesForUpload(ctx context.Context, upload *uploadsmodel.Upload) 
 	}
 
 	return indexReaders, nil
+}
+
+func (a API) RemoveShard(ctx context.Context, shardID id.ShardID) error {
+	return a.Repo.DeleteShard(ctx, shardID)
 }

--- a/pkg/preparation/sqlrepo/schema.sql
+++ b/pkg/preparation/sqlrepo/schema.sql
@@ -1,5 +1,6 @@
 -- enable foreign key constraints
 PRAGMA foreign_keys = ON;
+
 -- enable write ahead logging
 PRAGMA journal_mode = WAL;
 
@@ -147,7 +148,7 @@ CREATE TABLE IF NOT EXISTS nodes_in_shards (
   -- Offset of the node in the shard
   shard_offset INTEGER NOT NULL,
   FOREIGN KEY (node_cid, space_did) REFERENCES nodes(cid, space_did) ON DELETE CASCADE,
-  FOREIGN KEY (shard_id) REFERENCES shards(id),
+  FOREIGN KEY (shard_id) REFERENCES shards(id) ON DELETE CASCADE,
   PRIMARY KEY (node_cid, space_did, shard_id)
 ) STRICT;
 

--- a/pkg/preparation/sqlrepo/shards.go
+++ b/pkg/preparation/sqlrepo/shards.go
@@ -257,3 +257,15 @@ func (r *Repo) UpdateShard(ctx context.Context, shard *model.Shard) error {
 		return err
 	})
 }
+
+func (r *Repo) DeleteShard(ctx context.Context, shardID id.ShardID) error {
+	_, err := r.db.ExecContext(ctx, `
+		DELETE FROM shards
+		WHERE id = ?`,
+		shardID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to delete shard %s: %w", shardID, err)
+	}
+	return nil
+}

--- a/pkg/preparation/uploads/uploads.go
+++ b/pkg/preparation/uploads/uploads.go
@@ -33,6 +33,7 @@ type AddIndexesForUploadFunc func(ctx context.Context, uploadID id.UploadID, spa
 type AddStorachaUploadForUploadFunc func(ctx context.Context, uploadID id.UploadID, spaceDID did.DID) error
 type RemoveBadFSEntryFunc func(ctx context.Context, spaceDID did.DID, fsEntryID id.FSEntryID) error
 type RemoveBadNodesFunc func(ctx context.Context, spaceDID did.DID, nodeCIDs []cid.Cid) error
+type RemoveShardFunc func(ctx context.Context, shardID id.ShardID) error
 
 type API struct {
 	Repo                       Repo
@@ -43,6 +44,7 @@ type API struct {
 	AddStorachaUploadForUpload AddStorachaUploadForUploadFunc
 	RemoveBadFSEntry           RemoveBadFSEntryFunc
 	RemoveBadNodes             RemoveBadNodesFunc
+	RemoveShard                RemoveShardFunc
 
 	// AddNodeToUploadShards adds a node to the upload's shards, creating a new
 	// shard if necessary. It returns true if an existing open shard was closed,
@@ -200,18 +202,21 @@ func runDAGScanWorker(ctx context.Context, api API, uploadID id.UploadID, spaceD
 				return nil
 			})
 
-			var badFSEntryErr types.ErrBadFSEntry
-			if errors.As(err, &badFSEntryErr) {
+			var badFSEntriesErr types.ErrBadFSEntries
+			if errors.As(err, &badFSEntriesErr) {
 				upload, err := api.Repo.GetUploadByID(ctx, uploadID)
 				if err != nil {
 					return fmt.Errorf("getting upload %s after finding bad FS entry: %w", uploadID, err)
 				}
 
-				log.Debug("Removing bad FS entry from upload ", uploadID, ": ", badFSEntryErr.FsEntryID())
-				err = api.RemoveBadFSEntry(ctx, upload.SpaceDID(), badFSEntryErr.FsEntryID())
-				if err != nil {
-					return fmt.Errorf("removing bad FS entry for upload %s: %w", uploadID, err)
+				for _, badFSEntryErr := range badFSEntriesErr.Errs() {
+					log.Debug("Removing bad FS entry from upload ", uploadID, ": ", badFSEntryErr.FsEntryID())
+					err = api.RemoveBadFSEntry(ctx, upload.SpaceDID(), badFSEntryErr.FsEntryID())
+					if err != nil {
+						return fmt.Errorf("removing bad FS entry for upload %s: %w", uploadID, err)
+					}
 				}
+				log.Debug("Invalidating upload ", uploadID, " after removing bad FS entries")
 
 				err = upload.Invalidate()
 				if err != nil {
@@ -222,10 +227,6 @@ func runDAGScanWorker(ctx context.Context, api API, uploadID id.UploadID, spaceD
 				if err != nil {
 					return fmt.Errorf("updating upload %s after removing bad FS entry: %w", uploadID, err)
 				}
-
-				// Bubble the error to fail this attempt entirely. We're now ready for
-				// a retry.
-				return badFSEntryErr
 			}
 
 			if err != nil {
@@ -305,6 +306,19 @@ func runStorachaWorker(ctx context.Context, api API, uploadID id.UploadID, space
 						return fmt.Errorf("removing bad nodes for upload %s: %w", uploadID, err)
 					}
 
+					log.Debug("Removing bad shard for upload ", uploadID, ": ", badNodesErr.ShardID())
+					err = api.RemoveShard(ctx, badNodesErr.ShardID())
+					if err != nil {
+						return fmt.Errorf("removing bad shard %s for upload %s: %w", badNodesErr.ShardID(), uploadID, err)
+					}
+
+					log.Debug("Adding good CIDs back to upload in a different shard", uploadID, ": ", badNodesErr.GoodCIDs())
+					for _, goodCID := range badNodesErr.GoodCIDs().Keys() {
+						_, err := api.AddNodeToUploadShards(ctx, uploadID, spaceDID, goodCID)
+						if err != nil {
+							return fmt.Errorf("adding good CID %s back to upload %s: %w", goodCID, uploadID, err)
+						}
+					}
 					err = upload.Invalidate()
 					if err != nil {
 						return fmt.Errorf("invalidating upload %s after removing bad nodes: %w", uploadID, err)
@@ -314,10 +328,6 @@ func runStorachaWorker(ctx context.Context, api API, uploadID id.UploadID, space
 					if err != nil {
 						return fmt.Errorf("updating upload %s after removing bad nodes: %w", uploadID, err)
 					}
-
-					// Bubble the error to fail this attempt entirely. We're now ready for
-					// a retry.
-					return badNodesErr
 				}
 				return fmt.Errorf("`space/blob/add`ing shards for upload %s: %w", uploadID, err)
 			}


### PR DESCRIPTION
# Goals

I discovered by accident that if I stopped a 2GB simulated upload half way, then replaced all the data in the directory with a different 2GB structure (using randdir)... well, it was extremely hard, in fact impossible to resume all the way to completion. There were essentially two problems:
- Each run only potentially resolves one error, but there are potentially thousands of errors if the whole structure changes
- Some errors that should be recoverable became impossible to recover from -- such as shards that got too small to upload at all (or ran out of CIDs entirely)

This PR is the result of all my attempts to make this work smoothly, and now it does.

# Implementation

- adds an auto retry mode -- if you pass `--retry` to upload, it will automatically restart the upload until success
- properly marks bad FS entries as retriable
- identifies retriable errors (bad FS Entries, bad Nodes) by wrapping them in a RetriableErr struct
- makes more progress building dags before a failure - now a full iteration of dags scans run before returning a potentially multiple bad fs entries
- properly handles bad shards by not only removing items but putting the good CIDs back in the queue and deleting the shard. This is important cause the shard can get too small and potentially break if everything is emptied out.

# For Discussion

- THere's a schema.sql change in there. This is probably the last go we'll get without migrations
- should it be a number of retries?