### PR TITLE
fix: use multibase when encoding digests as strings 

### DIFF
--- a/cmd/internal/upload/ui/ui.go
+++ b/cmd/internal/upload/ui/ui.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/mattn/go-isatty"
 
+	"github.com/storacha/go-libstoracha/digestutil"
 	"github.com/storacha/guppy/internal/largeupload/bubbleup"
 	"github.com/storacha/guppy/pkg/preparation"
 	shardsmodel "github.com/storacha/guppy/pkg/preparation/shards/model"
@@ -220,7 +221,7 @@ func (m uploadModel) View() string {
 		uid := u.ID()
 		if shards, ok := m.recentAddedShards[uid]; ok {
 			for _, s := range shards {
-				output.WriteString(renderListItem(style.Foreground(addedShardColor), s.Digest().B58String(), s.Size()))
+				output.WriteString(renderListItem(style.Foreground(addedShardColor), digestutil.Format(s.Digest()), s.Size()))
 			}
 		}
 		if shards, ok := m.recentClosedShards[uid]; ok {

--- a/pkg/client/retrieve.go
+++ b/pkg/client/retrieve.go
@@ -10,6 +10,7 @@ import (
 	mh "github.com/multiformats/go-multihash"
 	contentcap "github.com/storacha/go-libstoracha/capabilities/space/content"
 	captypes "github.com/storacha/go-libstoracha/capabilities/types"
+	"github.com/storacha/go-libstoracha/digestutil"
 	"github.com/storacha/go-libstoracha/failure"
 	rclient "github.com/storacha/go-ucanto/client/retrieval"
 	"github.com/storacha/go-ucanto/core/dag/blockstore"
@@ -121,7 +122,7 @@ func (c *Client) Retrieve(ctx context.Context, space did.DID, location locator.L
 	}
 
 	if !bytes.Equal(expectedHash, dataDigest) {
-		return nil, fmt.Errorf("content hash mismatch for content %s; got %s", expectedHash.B58String(), dataDigest.B58String())
+		return nil, fmt.Errorf("content hash mismatch for content %s; got %s", digestutil.Format(expectedHash), digestutil.Format(dataDigest))
 	}
 
 	return data, nil

--- a/pkg/client/retrieve_test.go
+++ b/pkg/client/retrieve_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/storacha/go-libstoracha/blobindex"
 	assertcap "github.com/storacha/go-libstoracha/capabilities/assert"
 	captypes "github.com/storacha/go-libstoracha/capabilities/types"
+	"github.com/storacha/go-libstoracha/digestutil"
 	rclient "github.com/storacha/go-ucanto/client/retrieval"
 	"github.com/storacha/go-ucanto/core/delegation"
 	ed25519signer "github.com/storacha/go-ucanto/principal/ed25519/signer"
@@ -36,7 +37,7 @@ func TestRetrieve(t *testing.T) {
 		httpClient := testutil.NewRetrievalClient(t, storageProvider, testData)
 
 		// Use URL with hash in path
-		serverURL, err := url.Parse(fmt.Sprintf("https://storage1.example.com/blob/%s", dataHash.B58String()))
+		serverURL, err := url.Parse(fmt.Sprintf("https://storage1.example.com/blob/%s", digestutil.Format(dataHash)))
 		require.NoError(t, err)
 
 		// Create location commitment
@@ -99,7 +100,7 @@ func TestRetrieve(t *testing.T) {
 		httpClient := testutil.NewRetrievalClient(t, storageProvider, wrongData, testutil.WithoutHashValidation())
 
 		// Use URL with correct hash
-		serverURL, err := url.Parse(fmt.Sprintf("https://storage1.example.com/blob/%s", correctHash.B58String()))
+		serverURL, err := url.Parse(fmt.Sprintf("https://storage1.example.com/blob/%s", digestutil.Format(correctHash)))
 		require.NoError(t, err)
 
 		// Create location commitment with correct hash

--- a/pkg/client/testutil/retrievalclient.go
+++ b/pkg/client/testutil/retrievalclient.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/multiformats/go-multihash"
 	contentcap "github.com/storacha/go-libstoracha/capabilities/space/content"
+	"github.com/storacha/go-libstoracha/digestutil"
 	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/receipt/fx"
 	"github.com/storacha/go-ucanto/core/result"
@@ -77,7 +78,7 @@ func NewRetrievalClient(t *testing.T, service principal.Signer, testData []byte,
 						urlHashStr := urlPath[6:] // Remove "/blob/" prefix
 
 						// Parse the URL hash
-						urlHash, err := multihash.FromB58String(urlHashStr)
+						urlHash, err := digestutil.Parse(urlHashStr)
 						if err != nil {
 							return nil, nil, serverretrieval.Response{Status: http.StatusBadRequest}, fmt.Errorf("parsing URL hash: %w", err)
 						}

--- a/pkg/client/testutil/spaceblobadd.go
+++ b/pkg/client/testutil/spaceblobadd.go
@@ -21,6 +21,7 @@ import (
 	spaceblobcap "github.com/storacha/go-libstoracha/capabilities/space/blob"
 	captypes "github.com/storacha/go-libstoracha/capabilities/types"
 	ucancap "github.com/storacha/go-libstoracha/capabilities/ucan"
+	"github.com/storacha/go-libstoracha/digestutil"
 	"github.com/storacha/go-libstoracha/piece/digest"
 	"github.com/storacha/go-libstoracha/piece/piece"
 	"github.com/storacha/go-ucanto/core/delegation"
@@ -82,7 +83,7 @@ func executeAllocate(
 		return nil, fmt.Errorf("expected allocate capability, got %T", cap)
 	}
 
-	putBlobURL, err := url.Parse(storageURLPrefix + allocateMatch.Value().Nb().Blob.Digest.B58String())
+	putBlobURL, err := url.Parse(storageURLPrefix + digestutil.Format(allocateMatch.Value().Nb().Blob.Digest))
 	if err != nil {
 		return nil, fmt.Errorf("parsing put blob URL: %w", err)
 	}
@@ -573,7 +574,7 @@ func (r *blobPutTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		return nil, fmt.Errorf("unexpected PUT URL: %s", req.URL)
 	}
 	digestString := url[len(storageURLPrefix):]
-	digest, err := multihash.FromB58String(digestString)
+	digest, err := digestutil.Parse(digestString)
 	if err != nil {
 		return nil, fmt.Errorf("decoding multihash: %w", err)
 	}

--- a/pkg/preparation/preparation_test.go
+++ b/pkg/preparation/preparation_test.go
@@ -32,6 +32,7 @@ import (
 	spaceindexcap "github.com/storacha/go-libstoracha/capabilities/space/index"
 	"github.com/storacha/go-libstoracha/capabilities/types"
 	uploadcap "github.com/storacha/go-libstoracha/capabilities/upload"
+	"github.com/storacha/go-libstoracha/digestutil"
 	"github.com/storacha/go-ucanto/core/delegation"
 	"github.com/storacha/go-ucanto/core/invocation"
 	"github.com/storacha/go-ucanto/core/receipt/fx"
@@ -490,7 +491,7 @@ func newIndexAndShardsBlockstore(indexCID cid.Cid, shards ctestutil.BlobMap) (*i
 
 	indexDigest := indexCID.Hash()
 	if !shards.Has(indexDigest) {
-		return nil, fmt.Errorf("index CID %s (digest %s) not found in provided shards", indexCID, indexDigest.B58String())
+		return nil, fmt.Errorf("index CID %s (digest %s) not found in provided shards", indexCID, digestutil.Format(indexDigest))
 	}
 
 	index, err := blobindex.Extract(bytes.NewReader(shards.Get(indexDigest)))
@@ -509,7 +510,7 @@ func (c *indexAndShardsBlockstore) Get(ctx context.Context, key cid.Cid) (blocks
 		for sliceDigest, position := range sliceMap.Iterator() {
 			if bytes.Equal(key.Hash(), sliceDigest) {
 				if !c.shards.Has(shardDigest) {
-					return nil, fmt.Errorf("shard with digest %s not found in provided shards", shardDigest.B58String())
+					return nil, fmt.Errorf("shard with digest %s not found in provided shards", digestutil.Format(shardDigest))
 				}
 				shardBlob := c.shards.Get(shardDigest)
 				return blocks.NewBlockWithCid(shardBlob[position.Offset:position.Offset+position.Length], key)


### PR DESCRIPTION
This PR fixes string encoding of multihash digests to be multibase encoded. Instead of calling `digest.B58String()` we call `digestutil.Format(digest)`.

The multihash library `B58String()` method pre-dates multibase and so does not add a multibase prefix to the string it outputs. As a result the string looks like a [v0 CID](https://github.com/multiformats/cid#cidv0), which it is not - the data is not `dag-pb` encoded (the implicit data encoding for v0 CIDs). Using multibase encoding disambiguates these multihash digests from v0 CIDs.