### PR TITLE
allow output of `space generate` to re-direct to env var

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,8 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	cobra.EnableTraverseRunHooks = true
+	rootCmd.SetOut(os.Stdout)
+	rootCmd.SetErr(os.Stderr)
 
 	// default storacha dir: ~/.storacha/guppy
 	homedir, err := os.UserHomeDir()


### PR DESCRIPTION
- space goes to stdout, all other info to sdterr
- enables this sort of thing: `export SPACE=(./guppy space generate)`