### PR TITLE
fix(storacha): close shard readers

### DIFF
--- a/pkg/preparation/shards/shards.go
+++ b/pkg/preparation/shards/shards.go
@@ -215,7 +215,7 @@ func (a API) CloseUploadShards(ctx context.Context, uploadID id.UploadID) (bool,
 
 // ReaderForShard uses fastWriteShard connected to a pipe to provide an io.Reader
 // for shard data.
-func (a API) ReaderForShard(ctx context.Context, shardID id.ShardID) (io.Reader, error) {
+func (a API) ReaderForShard(ctx context.Context, shardID id.ShardID) (io.ReadCloser, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	// cancel when we're done writing or when we hit an error so that worker
 	// goroutines exit promptly.


### PR DESCRIPTION
# Goals

fix a memory leak by making sure that shard readers are always closed, which will trigger emptying of the buffers accumulated and termination of go routines

# Implementation

- Convert ReaderForShard to return a read closer, which the read on the io.Pipe already is
- Close the reader before addShard finishes
- Closing the reader on the pipe will case all writes to error, which will cause the underlying fastWriteShard function to terminate.

# For Discussion

Memory leak documentation:
<img width="1037" height="887" alt="heap" src="https://github.com/user-attachments/assets/3dd69265-57e0-449a-b568-f627381cc334" />
<img width="2249" height="2719" alt="goroutines" src="https://github.com/user-attachments/assets/7fa1e3e5-a222-4e88-856c-744650ae9bd6" />

The first image is a heap profile, the second is a go routine dump. (not at the same moment FWIW, but they're indicative)

Looks like the entierty of the memory leak is from fastWriteShard our parallel pipelining shard reader, reading blocks off disk and holding them in memory.

With parellelism 10, you would never expect more than 10 shards reads to be in progress at once. But if you look at the goroutine dump, 200 shard read go routines are in progress. 

The underlying problem is the shards are being read, but the goroutine keeps going. To cancel it, you need to close the reader, which will call fastWriteShard to error out, causing the goroutines to close