### PR TITLE
fix(shards): always reset hashes

### DIFF
--- a/pkg/preparation/shards/car.go
+++ b/pkg/preparation/shards/car.go
@@ -39,6 +39,7 @@ func init() {
 
 	noRootsHeader = buf.Bytes()
 	hasher := newShardHashState()
+	defer hasher.reset()
 	_, err = hasher.Write(noRootsHeader)
 	if err != nil {
 		panic(fmt.Sprintf("failed to hash CAR header: %v", err))


### PR DESCRIPTION
# Goal

always reset hash calculations to prevent hanging go-routines

# For Discussion

Yea commp calculations kickoff go-routines that can be left running if you don't reset the hash.

Is there a better way to implement this? The fact that I needed a generic seems off