### PR TITLE
refactor(storacha): seperate blob post process into seperate worker

### DIFF
--- a/pkg/preparation/preparation.go
+++ b/pkg/preparation/preparation.go
@@ -155,6 +155,8 @@ func NewAPI(repo Repo, client StorachaClient, options ...Option) API {
 		CloseUploadShards:          blobsAPI.CloseUploadShards,
 		CloseUploadIndexes:         blobsAPI.CloseUploadIndexes,
 		AddShardsForUpload:         storachaAPI.AddShardsForUpload,
+		PostProcessUploadedShards:  storachaAPI.PostProcessUploadedShards,
+		PostProcessUploadedIndexes: storachaAPI.PostProcessUploadedIndexes,
 		AddIndexesForUpload:        storachaAPI.AddIndexesForUpload,
 		AddStorachaUploadForUpload: storachaAPI.AddStorachaUploadForUpload,
 		RemoveBadFSEntry:           scansAPI.RemoveBadFSEntry,


### PR DESCRIPTION
# Goals

Speed up uploads by handling post processing steps for shards (replication/filecoin offer) after uploading in a separate step from running uploads.

Tests show that even at high parallelism bandwidth used can become inconsistent because so much time is spent waiting for the post process steps (specifically filecoin/offer) to complete. Here we seperate into a seperate bucket so as soon as upload completes, another upload can begin.

# Implementation

- Make "uploaded" a seperate state (arguably this could be computed from the presence/absence of a location claim, but that makes the query quite a bit more complicated)
- Seperate AddShardsForUpload into two steps: AddShardsForUpload and PostProcessUploadedShards
- Add a seperate working for post processing