### PR TITLE
fix(shards): fix a go-routine lock

### DIFF
--- a/pkg/preparation/shards/shards.go
+++ b/pkg/preparation/shards/shards.go
@@ -353,7 +353,7 @@ func (a API) fastWriteShard(ctx context.Context, shardID id.ShardID, offset uint
 
 	var closeErr error
 	for {
-		if resultsClosed && len(pending) == 0 {
+		if resultsClosed && (len(pending) == 0 || drainOnly) {
 			return closeErr
 		}
 


### PR DESCRIPTION
# Goal

Well, if the context gets cancelled, and there's anything in pending, this will infinite loop forever, which kinda sucks.

# Implementation

If we're drainign only, it really doesn't matter what's in pending