### PR TITLE
fix(sqlrepo): use RESTART mode for checkpoints

### DIFF
--- a/pkg/preparation/repo.go
+++ b/pkg/preparation/repo.go
@@ -68,9 +68,9 @@ func OpenRepo(ctx context.Context, dbPath string) (*sqlrepo.Repo, error) {
 		return nil, fmt.Errorf("failed to create SQL repo: %w", err)
 	}
 
-	// Start automatic WAL checkpointing to prevent unbounded WAL growth
+	// Start periodic forced WAL checkpointing to prevent unbounded WAL growth
 	// during long-running upload operations.
-	repo.StartAutoCheckpoint(ctx, sqlrepo.DefaultCheckpointInterval)
+	repo.StartPeriodicCheckpoint(ctx, sqlrepo.DefaultCheckpointInterval)
 
 	return repo, nil
 }


### PR DESCRIPTION
# Goals

This is a post facto cleanup of #270 .  It is a good idea to use RESTART mode. I did not disable auto-checkpointing as it runs based on usage rather than time, and much more frequently. The periodic checkpoint here in my opinion is a failsafe -- to force a full run in case autocheckpointing is not finishing.