### PR TITLE
feat: add delegation create command

### DIFF
--- a/cmd/delegation.go
+++ b/cmd/delegation.go
@@ -1,0 +1,10 @@
+package cmd
+
+import (
+	"github.com/storacha/guppy/cmd/delegation"
+)
+
+func init() {
+	delegation.StorePathP = &storePath
+	rootCmd.AddCommand(delegation.DelegationCmd)
+}

--- a/cmd/delegation/create.go
+++ b/cmd/delegation/create.go
@@ -1,0 +1,101 @@
+package delegation
+
+import (
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"slices"
+
+	"github.com/mitchellh/go-wordwrap"
+	"github.com/spf13/cobra"
+	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/go-ucanto/ucan"
+	"github.com/storacha/guppy/internal/cmdutil"
+	"github.com/storacha/guppy/pkg/client"
+)
+
+var createFlags struct {
+	can        []string
+	expiration int
+	output     string
+}
+
+var createCmd = &cobra.Command{
+	Use:   "create <space-did> <audience-did>",
+	Short: "Delegate capabilities for a space to others.",
+	Long: wordwrap.WrapString(
+		"Output a CAR encoded UCAN that delegates capabilities for a space to the audience.",
+		80),
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		space, err := did.Parse(args[0])
+		if err != nil {
+			return fmt.Errorf("parsing space DID: %w", err)
+		}
+		aud, err := did.Parse(args[1])
+		if err != nil {
+			return fmt.Errorf("parsing audience DID: %w", err)
+		}
+		if len(createFlags.can) == 0 {
+			return fmt.Errorf("at least one capability must be specified with --can")
+		}
+
+		c := cmdutil.MustGetClient(*StorePathP)
+		caps := make([]ucan.Capability[ucan.NoCaveats], 0, len(createFlags.can))
+		proofs := map[string]delegation.Proof{}
+		for _, can := range createFlags.can {
+			query := client.CapabilityQuery{Can: can, With: space.String()}
+			dlgs := c.Proofs(query)
+			if len(dlgs) == 0 {
+				return fmt.Errorf("no delegations found for ability %q with space %q", can, space.String())
+			}
+			for _, d := range dlgs {
+				proofs[d.Link().String()] = delegation.FromDelegation(d)
+			}
+			cap := ucan.NewCapability(can, space.String(), ucan.NoCaveats{})
+			caps = append(caps, cap)
+		}
+
+		opts := []delegation.Option{
+			delegation.WithProof(slices.Collect(maps.Values(proofs))...),
+		}
+		if createFlags.expiration > 0 {
+			opts = append(opts, delegation.WithExpiration(createFlags.expiration))
+		} else {
+			opts = append(opts, delegation.WithNoExpiration())
+		}
+
+		dlg, err := delegation.Delegate(c.Issuer(), aud, caps, opts...)
+		if err != nil {
+			return fmt.Errorf("creating delegation: %w", err)
+		}
+
+		if createFlags.output != "" {
+			data, err := io.ReadAll(delegation.Archive(dlg))
+			if err != nil {
+				return fmt.Errorf("reading delegation archive: %w", err)
+			}
+			err = os.WriteFile(createFlags.output, data, 0644)
+			if err != nil {
+				return fmt.Errorf("writing delegation archive: %w", err)
+			}
+		} else {
+			out, err := delegation.Format(dlg)
+			if err != nil {
+				return fmt.Errorf("formatting delegation: %w", err)
+			}
+			fmt.Println(out)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	createCmd.Flags().StringArrayVarP(&createFlags.can, "can", "c", nil, "One or more abilities to delegate.")
+	createCmd.Flags().IntVarP(&createFlags.expiration, "expiration", "e", 0, "Unix timestamp when the delegation is no longer valid. Zero indicates no expiration.")
+	createCmd.Flags().StringVarP(&createFlags.output, "output", "o", "", "Path to write the delegation CAR file to. If not specified, outputs to stdout.")
+	DelegationCmd.AddCommand(createCmd)
+}

--- a/cmd/delegation/delegation.go
+++ b/cmd/delegation/delegation.go
@@ -1,0 +1,10 @@
+package delegation
+
+import "github.com/spf13/cobra"
+
+var StorePathP *string
+
+var DelegationCmd = &cobra.Command{
+	Use:   "delegation",
+	Short: "Manage delegations",
+}


### PR DESCRIPTION
Similar to the JS client:

e.g.

`guppy delegation create <space> <audience> --can upload/add`