### PR TITLE
feat: add identity multihash support to gateway blockstore

### DIFF
--- a/cmd/gateway/serve.go
+++ b/cmd/gateway/serve.go
@@ -167,7 +167,7 @@ var serveCmd = &cobra.Command{
 			PublicGateways: pubGws,
 		}
 
-		blockStore := blockstore.NewBlockstore(arc.New(cfg.Gateway.BlockCacheCapacity))
+		blockStore := blockstore.NewIdStore(blockstore.NewBlockstore(arc.New(cfg.Gateway.BlockCacheCapacity)))
 		blockService := blockservice.New(blockStore, exchange)
 		backend, err := gateway.NewBlocksBackend(blockService)
 		cobra.CheckErr(err)


### PR DESCRIPTION
Allows hashes like `bafkqaaa` to be served.