### PR TITLE
fix: add network environment variables to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ Defaults shown in the following configuration TOML template:
 Guppy can be pointed to different Storacha Forge networks (e.g. a testing network). You can do that by setting the following environment variables:
 
 ```sh
-export STORACHA_SERVICE_URL="https://up.storacha.network"
-export STORACHA_SERVICE_DID="did:web:up.storacha.network"
-export STORACHA_RECEIPTS_URL="https://up.storacha.network/receipt/"
-export STORACHA_INDEXING_SERVICE_URL="https://indexer.storacha.network"
-export STORACHA_INDEXING_SERVICE_DID="did:web:indexer.storacha.network"
+export STORACHA_SERVICE_URL="https://up.forge.storacha.network"
+export STORACHA_SERVICE_DID="did:web:up.forge.storacha.network"
+export STORACHA_RECEIPTS_URL="https://up.forge.storacha.network/receipt/"
+export STORACHA_INDEXING_SERVICE_URL="https://indexer.forge.storacha.network"
+export STORACHA_INDEXING_SERVICE_DID="did:web:indexer.forge.storacha.network"
 ```
 
 ## Client library


### PR DESCRIPTION
Add the list of environment variables that need to be set to use guppy with other networks.

As a drive-by fix, I adjusted the level of the headings, bringing `Usage` at the same level as `Install`.