### PR TITLE
fix: Add missing `did` import

### DIFF
--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -12,6 +12,7 @@ import (
 
 	uclient "github.com/storacha/go-ucanto/client"
 	"github.com/storacha/go-ucanto/core/delegation"
+	"github.com/storacha/go-ucanto/did"
 	"github.com/storacha/go-ucanto/principal"
 	"github.com/storacha/go-ucanto/principal/ed25519/signer"
 	"github.com/storacha/go-ucanto/transport/car"


### PR DESCRIPTION
Not sure how that got merged… 😕

#### PR Dependency Tree


* **PR #332** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)