### PR TITLE
refactor: refactor `getLocalFSForPathFn`

### DIFF
--- a/pkg/preparation/preparation.go
+++ b/pkg/preparation/preparation.go
@@ -88,7 +88,7 @@ func NewAPI(repo Repo, client StorachaClient, options ...Option) API {
 			return fsys, nil
 		},
 		maxNodesPerIndex: defaultMaxNodesPerIndex,
-		bus: &bus.NoopBus{},
+		bus:              &bus.NoopBus{},
 	}
 	for _, opt := range options {
 		if err := opt(cfg); err != nil {


### PR DESCRIPTION
This PR refactors the `getLocalFSForPathFn` in the `/pkg/preparation/preparation.go`. This PR resolves issue #213 