### PR TITLE
feat: Add `--assume-unchanged-sources`

### DIFF
--- a/cmd/upload/root.go
+++ b/cmd/upload/root.go
@@ -25,15 +25,17 @@ import (
 var log = logging.Logger("cmd/upload")
 
 var rootFlags struct {
-	all         bool
-	retry       bool
-	parallelism uint64
+	all                    bool
+	retry                  bool
+	parallelism            uint64
+	assumeUnchangedSources bool
 }
 
 func init() {
 	Cmd.Flags().BoolVar(&rootFlags.all, "all", false, "Upload all sources (even if arguments are provided)")
 	Cmd.Flags().BoolVar(&rootFlags.retry, "retry", false, "Auto-retry failed uploads")
 	Cmd.Flags().Uint64Var(&rootFlags.parallelism, "parallelism", 6, "Number of parallel shard uploads to perform concurrently")
+	Cmd.Flags().BoolVar(&rootFlags.assumeUnchangedSources, "assume-unchanged-sources", false, "When resuming, skip filesystem rescan if a completed scan already exists")
 
 	Cmd.AddCommand(source.Cmd)
 }
@@ -92,6 +94,7 @@ var Cmd = &cobra.Command{
 
 		api := preparation.NewAPI(repo, client,
 			preparation.WithBlobUploadParallelism(int(rootFlags.parallelism)),
+			preparation.WithAssumeUnchangedSources(rootFlags.assumeUnchangedSources),
 			preparation.WithEventBus(eb),
 		)
 		allUploads, err := api.FindOrCreateUploads(ctx, spaceDID)

--- a/pkg/preparation/preparation.go
+++ b/pkg/preparation/preparation.go
@@ -54,10 +54,11 @@ type API struct {
 type Option func(cfg *config) error
 
 type config struct {
-	getLocalFSForPathFn   func(path string) (fs.FS, error)
-	maxNodesPerIndex      int
-	blobUploadParallelism int
-	bus                   bus.Bus
+	getLocalFSForPathFn    func(path string) (fs.FS, error)
+	maxNodesPerIndex       int
+	blobUploadParallelism  int
+	assumeUnchangedSources bool
+	bus                    bus.Bus
 }
 
 const defaultBlobUploadParallelism = 6
@@ -159,6 +160,7 @@ func NewAPI(repo Repo, client StorachaClient, options ...Option) API {
 
 	uploadsAPI = uploads.API{
 		Repo:                       repo,
+		AssumeUnchangedSources:     cfg.assumeUnchangedSources,
 		ExecuteScan:                scansAPI.ExecuteScan,
 		ExecuteDagScansForUpload:   dagsAPI.ExecuteDagScansForUpload,
 		AddNodesToUploadShards:     blobsAPI.AddNodesToUploadShards,
@@ -204,6 +206,13 @@ func WithGetLocalFSForPathFn(getLocalFSForPathFn func(path string) (fs.FS, error
 func WithMaxNodesPerIndex(maxNodesPerIndex int) Option {
 	return func(cfg *config) error {
 		cfg.maxNodesPerIndex = maxNodesPerIndex
+		return nil
+	}
+}
+
+func WithAssumeUnchangedSources(assume bool) Option {
+	return func(cfg *config) error {
+		cfg.assumeUnchangedSources = assume
 		return nil
 	}
 }


### PR DESCRIPTION
Adds an option to assume the filesystem hasn't changed when resuming, skipping the filesystem rescan. This makes it much faster to retry when you know the source hasn't changed since the last scan.








#### PR Dependency Tree


* **PR #344** 👈
  * **PR #358**
    * **PR #359**
      * **PR #360**
        * **PR #361**
          * **PR #362**
            * **PR #363**
              * **PR #364**
                * **PR #365**
                  * **PR #366**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)