### PR TITLE
fix: Only index *closed* shards

### DIFF
--- a/pkg/preparation/sqlrepo/indexes.go
+++ b/pkg/preparation/sqlrepo/indexes.go
@@ -17,6 +17,7 @@ func (r *Repo) ShardsNotInIndexes(ctx context.Context, uploadID id.UploadID) ([]
 		SELECT id
 		FROM shards
 		WHERE upload_id = ?
+		AND state = 'closed'
 		AND NOT EXISTS (
 			SELECT 1
 			FROM shards_in_indexes si


### PR DESCRIPTION
We were indexing shards (sometimes) before they were closed, potentially when they were still empty, which meant an infinite number could fit in one index. Then the shards would be filled up and the index would cover too much.

Now, shards don't get indexed until they're closed and can no longer grow.


#### PR Dependency Tree


* **PR #350** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)