### PR TITLE
fix: Backfill `slice_count` on `shards`

### DIFF
--- a/pkg/preparation/sqlrepo/migrations/20260223175900_add_node_uploads_shard_id_index.sql
+++ b/pkg/preparation/sqlrepo/migrations/20260223175900_add_node_uploads_shard_id_index.sql
@@ -1,6 +1,0 @@
--- +goose Up
-CREATE INDEX IF NOT EXISTS idx_node_uploads_shard_id
-  ON node_uploads (shard_id);
-
--- +goose Down
-DROP INDEX IF EXISTS idx_node_uploads_shard_id;


### PR DESCRIPTION
These were never filled in, meaning shards from before the column was created had an incorrect `slice_count` of 0.














#### PR Dependency Tree


* **PR #361** 👈
  * **PR #362**
    * **PR #363**
      * **PR #364**
        * **PR #365**
          * **PR #366**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)