### PR TITLE
feat: Log if blob PUT stalls

### DIFF
--- a/pkg/client/spaceblobadd.go
+++ b/pkg/client/spaceblobadd.go
@@ -646,29 +646,48 @@ func (p *progressReader) Read(b []byte) (int, error) {
 }
 
 type stallWarnReader struct {
-	r         io.Reader
-	name      string
-	threshold time.Duration
-	timer     *time.Timer
+	r          io.Reader
+	name       string
+	threshold  time.Duration
+	timer      *time.Timer
+	stallStart time.Time
+	warned     bool
 }
 
+var _ io.Reader = (*stallWarnReader)(nil)
+
+// newStallWarnReader wraps an io.Reader and logs a warning if no data is read
+// from it before [threshold], and again every [threshold] until some data is
+// read. The timer begins when the stallWarnReader is created, and is reset
+// after each successful read, until `stop()` is called.
 func newStallWarnReader(r io.Reader, name string, threshold time.Duration) *stallWarnReader {
 	sw := &stallWarnReader{
 		r:         r,
 		name:      name,
 		threshold: threshold,
 	}
+	sw.stallStart = time.Now()
 	sw.timer = time.AfterFunc(threshold, sw.warn)
 	return sw
 }
 
 func (sw *stallWarnReader) warn() {
-	log.Warnw("blob upload stalled", "destination", sw.name, "no_read_for", sw.threshold)
+	sw.warned = true
+	elapsed := time.Since(sw.stallStart)
+	log.Warnw("blob upload stalled", "destination", sw.name, "stalled_for", elapsed)
+	sw.timer.Reset(sw.threshold)
 }
 
 func (sw *stallWarnReader) Read(p []byte) (int, error) {
-	sw.timer.Reset(sw.threshold)
+	sw.timer.Stop()
+	if sw.warned {
+		sw.warned = false
+		elapsed := time.Since(sw.stallStart)
+		log.Warnw("blob upload stall ended", "destination", sw.name, "stalled_for", elapsed)
+	}
 	n, err := sw.r.Read(p)
+	sw.stallStart = time.Now()
+	sw.timer.Reset(sw.threshold)
 	return n, err
 }
 


### PR DESCRIPTION
Useful to see in logging.

















#### PR Dependency Tree


* **PR #364** 👈
  * **PR #365**
    * **PR #366**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)