### PR TITLE
feat(config): make config system the source of truth for network settings

### DIFF
--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -31,7 +31,7 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 
 		accounts, err := c.Accounts()
 		if err != nil {

--- a/cmd/blob/ls.go
+++ b/cmd/blob/ls.go
@@ -52,7 +52,7 @@ var lsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir, client.WithAdditionalProofs(proofs...))
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network, client.WithAdditionalProofs(proofs...))
 
 		spaceDID, err := cmdutil.ResolveSpace(c, args[0])
 		if err != nil {

--- a/cmd/delegation/create.go
+++ b/cmd/delegation/create.go
@@ -51,7 +51,7 @@ var createCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 
 		space, err := cmdutil.ResolveSpace(c, args[0])
 		if err != nil {

--- a/cmd/gateway/serve.go
+++ b/cmd/gateway/serve.go
@@ -108,7 +108,7 @@ var serveCmd = &cobra.Command{
 
 		indexHTML = []byte(strings.ReplaceAll(string(indexHTML), "{{.Version}}", build.Version))
 
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 
 		pub, err := crypto.UnmarshalEd25519PublicKey(c.Issuer().Verifier().Raw())
 		cobra.CheckErr(err)
@@ -146,7 +146,7 @@ var serveCmd = &cobra.Command{
 			spaces = slices.Collect(maps.Keys(authdSpaces))
 		}
 
-		indexer, indexerPrincipal := cmdutil.MustGetIndexClient()
+		indexer, indexerPrincipal := cmdutil.MustGetIndexClient(cfg.Network)
 		locator := locator.NewIndexLocator(indexer, func(spaces []did.DID) (delegation.Delegation, error) {
 			queries := make([]agentstore.CapabilityQuery, 0, len(spaces))
 			for _, space := range spaces {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -48,7 +48,7 @@ var loginCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 
 		authOk, err := c.RequestAccess(ctx, accountDid.String())
 		if err != nil {

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -46,7 +46,7 @@ var lsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir, client.WithAdditionalProofs(proofs...))
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network, client.WithAdditionalProofs(proofs...))
 
 		spaceDID, err := cmdutil.ResolveSpace(c, args[0])
 		if err != nil {

--- a/cmd/proof/add.go
+++ b/cmd/proof/add.go
@@ -36,7 +36,7 @@ var addCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 
 		if dlg.Audience().DID() != c.Issuer().DID() {
 			return fmt.Errorf("delegation audience %q does not match agent DID %q", dlg.Audience().DID(), c.Issuer().DID())

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -21,7 +21,7 @@ var resetCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 		return c.Reset()
 	},
 }

--- a/cmd/retrieve.go
+++ b/cmd/retrieve.go
@@ -46,7 +46,7 @@ var retrieveCmd = &cobra.Command{
 			return err
 		}
 
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 		space, err := cmdutil.ResolveSpace(c, args[0])
 		if err != nil {
 			return err
@@ -63,7 +63,7 @@ var retrieveCmd = &cobra.Command{
 
 		outputPath := args[2]
 
-		indexer, indexerPrincipal := cmdutil.MustGetIndexClient()
+		indexer, indexerPrincipal := cmdutil.MustGetIndexClient(cfg.Network)
 
 		ctx, span := tracer.Start(ctx, "retrieve", trace.WithAttributes(
 			attribute.String("retrieval.space", space.DID().String()),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,10 +31,7 @@ var (
 	configFilePath = path.Join("guppy", "config.toml")
 )
 
-var (
-	cfgFile      string
-	guppyDirPath string
-)
+var cfgFile string
 
 var rootCmd = &cobra.Command{
 	Use:   "guppy",
@@ -61,14 +58,6 @@ func init() {
 	}
 
 	rootCmd.AddCommand(unixfs.Cmd)
-	rootCmd.PersistentFlags().StringVar(
-		&guppyDirPath,
-		"guppy-dir",
-		"",
-		"Guppy Directory",
-	)
-
-	unixfs.StorePathP = &guppyDirPath
 
 	rootCmd.PersistentFlags().String(
 		"data-dir",
@@ -87,6 +76,25 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "Config file path. Attempts to load from user config directory if not set e.g. ~/.config/"+configFilePath)
 
 	rootCmd.PersistentFlags().Bool("ui", false, "Use the guppy UI")
+
+	// Network configuration flags
+	rootCmd.PersistentFlags().StringP("network", "n", "", "Network preset name (forge, hot, warm-staging)")
+	cobra.CheckErr(viper.BindPFlag("network.name", rootCmd.PersistentFlags().Lookup("network")))
+
+	rootCmd.PersistentFlags().String("upload-service-did", "", "Upload service DID (overrides network preset)")
+	cobra.CheckErr(viper.BindPFlag("network.upload_id", rootCmd.PersistentFlags().Lookup("upload-service-did")))
+
+	rootCmd.PersistentFlags().String("upload-service-url", "", "Upload service URL (overrides network preset)")
+	cobra.CheckErr(viper.BindPFlag("network.upload_url", rootCmd.PersistentFlags().Lookup("upload-service-url")))
+
+	rootCmd.PersistentFlags().String("receipts-url", "", "Receipts service URL (overrides network preset)")
+	cobra.CheckErr(viper.BindPFlag("network.receipts_url", rootCmd.PersistentFlags().Lookup("receipts-url")))
+
+	rootCmd.PersistentFlags().String("indexer-did", "", "Indexing service DID (overrides network preset)")
+	cobra.CheckErr(viper.BindPFlag("network.indexer_id", rootCmd.PersistentFlags().Lookup("indexer-did")))
+
+	rootCmd.PersistentFlags().String("indexer-url", "", "Indexing service URL (overrides network preset)")
+	cobra.CheckErr(viper.BindPFlag("network.indexer_url", rootCmd.PersistentFlags().Lookup("indexer-url")))
 
 	// Add Commands
 	rootCmd.AddCommand(

--- a/cmd/space/generate.go
+++ b/cmd/space/generate.go
@@ -79,7 +79,7 @@ var generateCmd = &cobra.Command{
 			return err
 		}
 
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 		accounts, err := c.Accounts()
 		if err != nil {
 			return err

--- a/cmd/space/info.go
+++ b/cmd/space/info.go
@@ -32,7 +32,7 @@ var infoCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 
 		spaceDID, err := cmdutil.ResolveSpace(c, args[0])
 		if err != nil {

--- a/cmd/space/list.go
+++ b/cmd/space/list.go
@@ -32,7 +32,7 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 
 		spaces, err := c.Spaces()
 		if err != nil {

--- a/cmd/space/provision.go
+++ b/cmd/space/provision.go
@@ -34,7 +34,7 @@ var provisionCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 
 		spaceDID, err := cmdutil.ResolveSpace(c, args[0])
 		if err != nil {

--- a/cmd/unixfs/ls.go
+++ b/cmd/unixfs/ls.go
@@ -17,6 +17,7 @@ import (
 	"github.com/storacha/guppy/internal/cmdutil"
 	"github.com/storacha/guppy/pkg/client/dagservice"
 	"github.com/storacha/guppy/pkg/client/locator"
+	"github.com/storacha/guppy/pkg/config"
 	"github.com/storacha/guppy/pkg/dagfs"
 )
 
@@ -52,8 +53,13 @@ var lsCmd = &cobra.Command{
 			return fmt.Errorf("invalid root CID: %w", err)
 		}
 
-		c := cmdutil.MustGetClient(*StorePathP)
-		indexer, indexerPrincipal := cmdutil.MustGetIndexClient()
+		cfg, err := config.Load[config.Config]()
+		if err != nil {
+			return err
+		}
+
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
+		indexer, indexerPrincipal := cmdutil.MustGetIndexClient(cfg.Network)
 
 		proofs, err := c.Proofs()
 		if err != nil {

--- a/cmd/unixfs/unixfs.go
+++ b/cmd/unixfs/unixfs.go
@@ -4,8 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var StorePathP *string
-
 var Cmd = &cobra.Command{
 	Use:   "unixfs",
 	Short: "Interact with UnixFS data",

--- a/cmd/upload/root.go
+++ b/cmd/upload/root.go
@@ -84,7 +84,7 @@ var Cmd = &cobra.Command{
 		// end of this function anyhow.
 		// defer repo.Close()
 
-		client := cmdutil.MustGetClient(cfg.Repo.Dir)
+		client := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 		spaceDID, err := cmdutil.ResolveSpace(client, spaceArg)
 		if err != nil {
 			return err

--- a/cmd/upload/source/add.go
+++ b/cmd/upload/source/add.go
@@ -67,7 +67,7 @@ var AddCmd = &cobra.Command{
 			return fmt.Errorf("resolving absolute path: %w", err)
 		}
 
-		client := cmdutil.MustGetClient(cfg.Repo.Dir)
+		client := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 		spaceDID, err := cmdutil.ResolveSpace(client, spaceArg)
 		if err != nil {
 			return err

--- a/cmd/upload/source/list.go
+++ b/cmd/upload/source/list.go
@@ -36,7 +36,7 @@ var ListCmd = &cobra.Command{
 			return fmt.Errorf("space cannot be empty")
 		}
 
-		spaceDID, err := cmdutil.ResolveSpace(cmdutil.MustGetClient(cfg.Repo.Dir), spaceArg)
+		spaceDID, err := cmdutil.ResolveSpace(cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network), spaceArg)
 		if err != nil {
 			return err
 		}

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -44,10 +44,9 @@ var verifyCmd = &cobra.Command{
 			return fmt.Errorf("parsing root CID: %w", err)
 		}
 
-		networkName, _ := cmd.Flags().GetString("network")
-		network := cmdutil.MustGetNetworkConfig(networkName)
+		network := cmdutil.MustGetNetworkConfig(cfg.Network, "")
 
-		guppy := cmdutil.MustGetClientForNetwork(cfg.Repo.Dir, networkName)
+		guppy := cmdutil.MustGetClientForNetwork(cfg.Repo.Dir, cfg.Network, "")
 		allProofs, err := guppy.Proofs(agentstore.CapabilityQuery{Can: contentcap.RetrieveAbility})
 		if err != nil {
 			return err
@@ -147,8 +146,6 @@ var verifyCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(verifyCmd)
-	verifyCmd.Flags().StringP("network", "n", "", "Network to verify content retrieval from.")
-	verifyCmd.Flags().MarkHidden("network")
 }
 
 type verifyModel struct {

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -17,7 +17,7 @@ var whoamiCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		c := cmdutil.MustGetClient(cfg.Repo.Dir)
+		c := cmdutil.MustGetClient(cfg.Repo.Dir, cfg.Network)
 		cmd.Println(c.DID())
 		return nil
 	},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 type Config struct {
 	Repo    RepoConfig    `mapstructure:"repo" toml:"repo"`
 	Gateway GatewayConfig `mapstructure:"gateway" toml:"gateway"`
+	Network NetworkConfig `mapstructure:"network" toml:"network"`
 }
 
 func (c Config) Validate() error {
@@ -16,7 +17,10 @@ func (c Config) Validate() error {
 	if err != nil {
 		return err
 	}
-	return c.Gateway.Validate()
+	if err := c.Gateway.Validate(); err != nil {
+		return err
+	}
+	return c.Network.Validate()
 }
 
 func Load[T Validatable]() (T, error) {

--- a/pkg/config/network.go
+++ b/pkg/config/network.go
@@ -1,0 +1,144 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/storacha/go-ucanto/did"
+	"github.com/storacha/guppy/pkg/presets"
+)
+
+// NetworkConfig holds network-related configuration that can be specified in
+// the config file. All fields are optional. If Name is set, it refers to a
+// preset network configuration (forge, hot, warm-staging). Other fields can
+// override individual values from the preset.
+type NetworkConfig struct {
+	// Name is the name of a preset network (forge, hot, warm-staging).
+	// If set, other fields override values from the preset.
+	Name string `mapstructure:"name" toml:"name"`
+	// UploadID is the DID of the upload service.
+	UploadID string `mapstructure:"upload_id" toml:"upload_id"`
+	// UploadURL is the URL of the upload service.
+	UploadURL string `mapstructure:"upload_url" toml:"upload_url"`
+	// ReceiptsURL is the URL of the receipts service.
+	ReceiptsURL string `mapstructure:"receipts_url" toml:"receipts_url"`
+	// IndexerID is the DID of the indexing service.
+	IndexerID string `mapstructure:"indexer_id" toml:"indexer_id"`
+	// IndexerURL is the URL of the indexing service.
+	IndexerURL string `mapstructure:"indexer_url" toml:"indexer_url"`
+	// AuthorizedRetrievals indicates whether UCAN authorized retrievals are supported.
+	// Use a pointer to distinguish between unset and false.
+	AuthorizedRetrievals *bool `mapstructure:"authorized_retrievals" toml:"authorized_retrievals"`
+}
+
+// IsEmpty returns true if no network configuration fields are set.
+func (n NetworkConfig) IsEmpty() bool {
+	return n.Name == "" &&
+		n.UploadID == "" &&
+		n.UploadURL == "" &&
+		n.ReceiptsURL == "" &&
+		n.IndexerID == "" &&
+		n.IndexerURL == "" &&
+		n.AuthorizedRetrievals == nil
+}
+
+// Validate validates the network configuration.
+func (n NetworkConfig) Validate() error {
+	if n.UploadID != "" {
+		if _, err := did.Parse(n.UploadID); err != nil {
+			return fmt.Errorf("invalid network.upload_id: %w", err)
+		}
+	}
+	if n.UploadURL != "" {
+		if _, err := url.Parse(n.UploadURL); err != nil {
+			return fmt.Errorf("invalid network.upload_url: %w", err)
+		}
+	}
+	if n.ReceiptsURL != "" {
+		if _, err := url.Parse(n.ReceiptsURL); err != nil {
+			return fmt.Errorf("invalid network.receipts_url: %w", err)
+		}
+	}
+	if n.IndexerID != "" {
+		if _, err := did.Parse(n.IndexerID); err != nil {
+			return fmt.Errorf("invalid network.indexer_id: %w", err)
+		}
+	}
+	if n.IndexerURL != "" {
+		if _, err := url.Parse(n.IndexerURL); err != nil {
+			return fmt.Errorf("invalid network.indexer_url: %w", err)
+		}
+	}
+	return nil
+}
+
+// ToPresetConfig converts this config to a presets.NetworkConfig, using the
+// specified base preset name as a starting point. If baseName is empty and this
+// config's Name is also empty, the default network is used. Config values
+// override preset values when set.
+func (n NetworkConfig) ToPresetConfig(baseName string) (presets.NetworkConfig, error) {
+	// Determine which preset to use as base
+	presetName := baseName
+	if presetName == "" {
+		presetName = n.Name
+	}
+
+	// Get the base preset (this also handles STORACHA_* env vars for backward compat)
+	network, err := presets.GetNetworkConfig(presetName)
+	if err != nil {
+		return presets.NetworkConfig{}, err
+	}
+
+	// Override with config values if present
+	if n.UploadID != "" {
+		id, err := did.Parse(n.UploadID)
+		if err != nil {
+			return presets.NetworkConfig{}, fmt.Errorf("parsing network.upload_id: %w", err)
+		}
+		network.UploadID = id
+		network.Name = "custom"
+	}
+
+	if n.UploadURL != "" {
+		u, err := url.Parse(n.UploadURL)
+		if err != nil {
+			return presets.NetworkConfig{}, fmt.Errorf("parsing network.upload_url: %w", err)
+		}
+		network.UploadURL = *u
+		network.Name = "custom"
+	}
+
+	if n.ReceiptsURL != "" {
+		u, err := url.Parse(n.ReceiptsURL)
+		if err != nil {
+			return presets.NetworkConfig{}, fmt.Errorf("parsing network.receipts_url: %w", err)
+		}
+		network.ReceiptsURL = *u
+		network.Name = "custom"
+	}
+
+	if n.IndexerID != "" {
+		id, err := did.Parse(n.IndexerID)
+		if err != nil {
+			return presets.NetworkConfig{}, fmt.Errorf("parsing network.indexer_id: %w", err)
+		}
+		network.IndexerID = id
+		network.Name = "custom"
+	}
+
+	if n.IndexerURL != "" {
+		u, err := url.Parse(n.IndexerURL)
+		if err != nil {
+			return presets.NetworkConfig{}, fmt.Errorf("parsing network.indexer_url: %w", err)
+		}
+		network.IndexerURL = *u
+		network.Name = "custom"
+	}
+
+	if n.AuthorizedRetrievals != nil {
+		network.AuthorizedRetrievals = *n.AuthorizedRetrievals
+		network.Name = "custom"
+	}
+
+	return network, nil
+}


### PR DESCRIPTION
make config system the source of truth for network sett…

Previously, network configuration was determined at runtime by looking up environment variables (STORACHA_NETWORK, STORACHA_*) in the presets package. This made it difficult to configure guppy declaratively via config file.

This change introduces a NetworkConfig struct in pkg/config that can be specified in config.toml under [network]. All command-line tools now pass the loaded config through to client creation, allowing the config file to serve as the primary source of truth.

Precedence order (highest to lowest):
1. CLI flags (--network, --upload-service-did, etc.)
2. Config file [network] section
3. Environment variables (STORACHA_* for backwards compatibility)
4. Default network preset

Changes:
- Add pkg/config/network.go with NetworkConfig struct
- Update pkg/config/config.go to include Network field
- Update internal/cmdutil/cmdutil.go to accept NetworkConfig
- Add network flags to cmd/root.go (--network, --upload-service-did, etc.)
- Update all commands to pass cfg.Network to client functions