### PR TITLE
fix: Avoid DB deadlock

### DIFF
--- a/pkg/preparation/blobs/blobs.go
+++ b/pkg/preparation/blobs/blobs.go
@@ -377,23 +377,22 @@ func (a API) fastWriteShard(ctx context.Context, shardID id.ShardID, offset uint
 	go func() {
 		defer close(jobs)
 
-		idx := 0
+		var jobSlice []job
+
 		for nis, err := range a.Repo.NodesInShard(ctx, shardID, offset) {
 			if err != nil {
-				// If we fail to iterate nodes, send the error and stop producing jobs.
-				select {
-				case <-ctx.Done():
-					return
-				case results <- result{err: fmt.Errorf("failed to iterate nodes in shard %s: %w", shardID, err)}:
-				}
+				results <- result{err: fmt.Errorf("failed to iterate nodes in shard %s: %w", shardID, err)}
 				return
 			}
+			jobSlice = append(jobSlice, job{idx: len(jobSlice), node: nis.Node})
+		}
+
+		for _, j := range jobSlice {
 			select {
 			case <-ctx.Done():
 				return
-			case jobs <- job{idx: idx, node: nis.Node}:
+			case jobs <- j:
 			}
-			idx++
 		}
 	}()
 

--- a/pkg/preparation/blobs/repo.go
+++ b/pkg/preparation/blobs/repo.go
@@ -30,8 +30,11 @@ type Repo interface {
 	// CreateNodeUpload creates a node_uploads record with shard_id = NULL.
 	CreateNodeUpload(ctx context.Context, nodeCID cid.Cid, spaceDID did.DID, uploadID id.UploadID) error
 	FindNodeByCIDAndSpaceDID(ctx context.Context, c cid.Cid, spaceDID did.DID) (dagsmodel.Node, error)
-	// NodesInShard iterates over all the nodes for a given shard, in the
-	// order they should appear in the shard.
+	// NodesInShard iterates over all the nodes for a given shard, in the order
+	// they should appear in the shard. NB: A DB connection will be held open for
+	// the duration of the iteration, so when using a single connection, callers
+	// should not make and wait for additional queries before finishing iteration,
+	// or the iteration will deadlock.
 	NodesInShard(ctx context.Context, shardID id.ShardID, startOffset uint64) iter.Seq2[NodeInShard, error]
 	GetSpaceByDID(ctx context.Context, spaceDID did.DID) (*spacesmodel.Space, error)
 	DeleteShard(ctx context.Context, shardID id.ShardID) error


### PR DESCRIPTION
This is pretty important. Under SQLite, this is consistently locking up the uploader for me. Not sure why it didn't seem to fail before, though. Possibly an oddity of using the real staging network for the test; this discovery came out of moving to Smelt for `doupload`.


#### PR Dependency Tree


* **PR #397** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)